### PR TITLE
Undo changes of branch iwan-ssh-test-dependency (e45c1ff)

### DIFF
--- a/reahl-dev/reahl/dev_dev/test_domain.py
+++ b/reahl-dev/reahl/dev_dev/test_domain.py
@@ -78,14 +78,7 @@ class RepositoryUploadFixture(Fixture):
 
     def new_debian_repository(self):
         user = os.environ.get('USER', None)
-
-        @stubclass(SshRepository)
-        class SshRepositoryStub(SshRepository):
-            def transfer(self, package):
-                files = package.files_to_distribute
-                Executable('cp').check_call(files+['%s' % self.destination])
-
-        return SshRepositoryStub(self.workspace, 'localhost', user, self.incoming_directory.name)
+        return SshRepository(self.workspace, 'localhost', user, self.incoming_directory.name)
 
 
 @istest


### PR DESCRIPTION
Resolves one of the issues in #54 : We will have to undo #47 now, as that workaround was not necessary....
