### PR TITLE
Merge "reahl" and "reahl-control" into one "reahl" command

### DIFF
--- a/.reahlalias
+++ b/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- check

--- a/.reahlproject
+++ b/.reahlproject
@@ -69,6 +69,5 @@
     <packageindex repository="pypi"/>
   </distpackage>
 
-  <alias name="unit" command="setup -- check"/>
 </project>
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ before_install:
 install:
   - "python scripts/bootstrap.py --script-dependencies"
   - CFLAGS="-O0" python scripts/bootstrap.py --pip-installs
-  - "reahl-control createdb -U postgres reahl-web/etc"
+  - "reahl createdb -U postgres reahl-web/etc"
   - "reahl setup -sX -- develop -N"
 
 before_script:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,7 +18,7 @@ Vagrant.configure(2) do |config|
   config.vm.provision "shell", privileged: false, inline: <<-SHELL
     cd /vagrant
     python scripts/bootstrap.py --script-dependencies && python scripts/bootstrap.py --pip-installs
-    reahl-control createdb reahl-web/etc
+    reahl createdb reahl-web/etc
   SHELL
 end
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -30,6 +30,8 @@ python-reahl (4.0.0a1) unstable; urgency=low
  * Changed DriverBrowser.press_tab to operate on the element with focus.
  * Upgraded BS4(BeautifulSoup) version to 4.6.
  * Upgraded Lxml version to 3.8.
+ * Changed 'reahl' alias mechanism to not be read from .reahlproject.
+ * Merged 'reahl' and 'reahl-control' into a single command.
 
  -- Iwan Vosloo <iwan@reahl.org>  Thu, 12 Jun 2016 08:47:00 +0200
 

--- a/reahl-bzrsupport/.reahlalias
+++ b/reahl-bzrsupport/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.bzrsupport_dev'

--- a/reahl-bzrsupport/.reahlproject
+++ b/reahl-bzrsupport/.reahlproject
@@ -19,7 +19,6 @@
 
   <export entrypoint="reahl.dev.xmlclasses" name="BzrSourceControl" locator="reahl.bzrsupport:BzrSourceControl"/>
 
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.bzrsupport_dev'"/>
 
   <distpackage type="wheel">
     <packageindex repository="pypi"/>

--- a/reahl-component/.reahlalias
+++ b/reahl-component/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.component_dev'

--- a/reahl-component/.reahlproject
+++ b/reahl-component/.reahlproject
@@ -29,29 +29,29 @@
     <egg name="reahl-sqlitesupport"/>
   </deps>
 
-  <script name="reahl-control" locator="reahl.component.prodshell:ProductionCommandline.execute_one"/>
+  <script name="reahl" locator="reahl.component.shelltools:ReahlCommandline.execute_one"/>
   
-  <export entrypoint="reahl.component.prodcommands" name="CreateDBUser" locator="reahl.component.prodshell:CreateDBUser"/>
-  <export entrypoint="reahl.component.prodcommands" name="DropDBUser" locator="reahl.component.prodshell:DropDBUser"/>
-  <export entrypoint="reahl.component.prodcommands" name="CreateDB" locator="reahl.component.prodshell:CreateDB"/>
-  <export entrypoint="reahl.component.prodcommands" name="DropDB" locator="reahl.component.prodshell:DropDB"/>
-  <export entrypoint="reahl.component.prodcommands" name="BackupDB" locator="reahl.component.prodshell:BackupDB"/>
-  <export entrypoint="reahl.component.prodcommands" name="RestoreDB" locator="reahl.component.prodshell:RestoreDB"/>
-  <export entrypoint="reahl.component.prodcommands" name="BackupAllDB" locator="reahl.component.prodshell:BackupAllDB"/>
-  <export entrypoint="reahl.component.prodcommands" name="RestoreAllDB" locator="reahl.component.prodshell:RestoreAllDB"/>
-  <export entrypoint="reahl.component.prodcommands" name="SizeDB" locator="reahl.component.prodshell:SizeDB"/>
-  <export entrypoint="reahl.component.prodcommands" name="RunJobs" locator="reahl.component.prodshell:RunJobs"/>
-  <export entrypoint="reahl.component.prodcommands" name="CreateDBTables" locator="reahl.component.prodshell:CreateDBTables"/>
-  <export entrypoint="reahl.component.prodcommands" name="DropDBTables" locator="reahl.component.prodshell:DropDBTables"/>
-  <export entrypoint="reahl.component.prodcommands" name="MigrateDB" locator="reahl.component.prodshell:MigrateDB"/>
-  <export entrypoint="reahl.component.prodcommands" name="DiffDB" locator="reahl.component.prodshell:DiffDB"/>
-  <export entrypoint="reahl.component.prodcommands" name="ListConfig" locator="reahl.component.prodshell:ListConfig"/>
-  <export entrypoint="reahl.component.prodcommands" name="CheckConfig" locator="reahl.component.prodshell:CheckConfig"/>
-  <export entrypoint="reahl.component.prodcommands" name="ListDependencies" locator="reahl.component.prodshell:ListDependencies"/>
+  <export entrypoint="reahl.component.commands" name="CreateDBUser" locator="reahl.component.prodshell:CreateDBUser"/>
+  <export entrypoint="reahl.component.commands" name="DropDBUser" locator="reahl.component.prodshell:DropDBUser"/>
+  <export entrypoint="reahl.component.commands" name="CreateDB" locator="reahl.component.prodshell:CreateDB"/>
+  <export entrypoint="reahl.component.commands" name="DropDB" locator="reahl.component.prodshell:DropDB"/>
+  <export entrypoint="reahl.component.commands" name="BackupDB" locator="reahl.component.prodshell:BackupDB"/>
+  <export entrypoint="reahl.component.commands" name="RestoreDB" locator="reahl.component.prodshell:RestoreDB"/>
+  <export entrypoint="reahl.component.commands" name="BackupAllDB" locator="reahl.component.prodshell:BackupAllDB"/>
+  <export entrypoint="reahl.component.commands" name="RestoreAllDB" locator="reahl.component.prodshell:RestoreAllDB"/>
+  <export entrypoint="reahl.component.commands" name="SizeDB" locator="reahl.component.prodshell:SizeDB"/>
+  <export entrypoint="reahl.component.commands" name="RunJobs" locator="reahl.component.prodshell:RunJobs"/>
+  <export entrypoint="reahl.component.commands" name="CreateDBTables" locator="reahl.component.prodshell:CreateDBTables"/>
+  <export entrypoint="reahl.component.commands" name="DropDBTables" locator="reahl.component.prodshell:DropDBTables"/>
+  <export entrypoint="reahl.component.commands" name="MigrateDB" locator="reahl.component.prodshell:MigrateDB"/>
+  <export entrypoint="reahl.component.commands" name="DiffDB" locator="reahl.component.prodshell:DiffDB"/>
+  <export entrypoint="reahl.component.commands" name="ListConfig" locator="reahl.component.prodshell:ListConfig"/>
+  <export entrypoint="reahl.component.commands" name="CheckConfig" locator="reahl.component.prodshell:CheckConfig"/>
+  <export entrypoint="reahl.component.commands" name="ListDependencies" locator="reahl.component.prodshell:ListDependencies"/>
+  <export entrypoint="reahl.component.commands" name="AddAlias" locator="reahl.component.shelltools:AddAlias"/>
 
   <export entrypoint="reahl.component.databasecontrols" name="NullDatabaseControl" locator="reahl.component.dbutils:NullDatabaseControl"/>
 
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.component_dev'"/>
 
   <distpackage type="wheel">
     <packageindex repository="pypi"/>

--- a/reahl-component/reahl/component/prodshell.py
+++ b/reahl-component/reahl/component/prodshell.py
@@ -24,16 +24,12 @@ import six
 from pkg_resources import DistributionNotFound
 
 from reahl.component.dbutils import SystemControl
-from reahl.component.shelltools import Command, ReahlCommandline
+from reahl.component.shelltools import Command, ReahlCommandline, AliasFile
 from reahl.component.context import ExecutionContext
 from reahl.component.config import EntryPointClassList, Configuration, StoredConfiguration, MissingValue
 from reahl.component.eggs import ReahlEgg
 
 
-
-
-class ProdShellConfig(Configuration):
-    commands = EntryPointClassList('reahl.component.prodcommands', description='The commands (classes) available to the production commandline shell')
 
 
 class ProductionCommand(Command):
@@ -295,9 +291,4 @@ class RunJobs(ProductionCommand):
         return 0
 
 
-
-class ProductionCommandline(ReahlCommandline):
-    """The main class for invoking commands on projects in production environments."""
-    def __init__(self, options):
-        super(ProductionCommandline, self).__init__(options, ProdShellConfig())
 

--- a/reahl-dev/.reahlalias
+++ b/reahl-dev/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.dev_dev'

--- a/reahl-dev/.reahlproject
+++ b/reahl-dev/.reahlproject
@@ -26,8 +26,6 @@
     <egg name="reahl-stubble"/>
   </deps>
 
-  <script name="reahl" locator="reahl.dev.devshell:WorkspaceCommandline.execute_one"/>
-  
   <export entrypoint="reahl.dev.xmlclasses" name="MetaInfo" locator="reahl.dev.devdomain:MetaInfo"/>
   <export entrypoint="reahl.dev.xmlclasses" name="HardcodedMetadata" locator="reahl.dev.devdomain:HardcodedMetadata"/>
   <export entrypoint="reahl.dev.xmlclasses" name="DebianPackageMetadata" locator="reahl.dev.devdomain:DebianPackageMetadata"/>
@@ -67,35 +65,34 @@
   <export entrypoint="reahl.dev.xmlclasses" name="ExtraPath" locator="reahl.dev.devdomain:ExtraPath"/>
   <export entrypoint="reahl.dev.xmlclasses" name="ProjectTag" locator="reahl.dev.devdomain:ProjectTag"/>
 
-  <export entrypoint="reahl.dev.commands" name="Refresh" locator="reahl.dev.devshell:Refresh"/>
-  <export entrypoint="reahl.dev.commands" name="ExplainLegend" locator="reahl.dev.devshell:ExplainLegend"/>
-  <export entrypoint="reahl.dev.commands" name="List" locator="reahl.dev.devshell:List"/>
-  <export entrypoint="reahl.dev.commands" name="Select" locator="reahl.dev.devshell:Select"/>
-  <export entrypoint="reahl.dev.commands" name="ClearSelection" locator="reahl.dev.devshell:ClearSelection"/>
-  <export entrypoint="reahl.dev.commands" name="ListSelections" locator="reahl.dev.devshell:ListSelections"/>
-  <export entrypoint="reahl.dev.commands" name="Save" locator="reahl.dev.devshell:Save"/>
-  <export entrypoint="reahl.dev.commands" name="Read" locator="reahl.dev.devshell:Read"/>
-  <export entrypoint="reahl.dev.commands" name="DeleteSelection" locator="reahl.dev.devshell:DeleteSelection"/>
-  <export entrypoint="reahl.dev.commands" name="Shell" locator="reahl.dev.devshell:Shell"/>
-  <export entrypoint="reahl.dev.commands" name="Setup" locator="reahl.dev.devshell:Setup"/>
-  <export entrypoint="reahl.dev.commands" name="Build" locator="reahl.dev.devshell:Build"/>
-  <export entrypoint="reahl.dev.commands" name="ListMissingDependencies" locator="reahl.dev.devshell:ListMissingDependencies"/>
-  <export entrypoint="reahl.dev.commands" name="DebInstall" locator="reahl.dev.devshell:DebInstall"/>
-  <export entrypoint="reahl.dev.commands" name="Upload" locator="reahl.dev.devshell:Upload"/>
-  <export entrypoint="reahl.dev.commands" name="MarkReleased" locator="reahl.dev.devshell:MarkReleased"/>
-  <export entrypoint="reahl.dev.commands" name="SubstVars" locator="reahl.dev.devshell:SubstVars"/>
-  <export entrypoint="reahl.dev.commands" name="Debianise" locator="reahl.dev.devshell:Debianise"/>
-  <export entrypoint="reahl.dev.commands" name="Info" locator="reahl.dev.devshell:Info"/>
+  <export entrypoint="reahl.component.commands" name="Refresh" locator="reahl.dev.devshell:Refresh"/>
+  <export entrypoint="reahl.component.commands" name="ExplainLegend" locator="reahl.dev.devshell:ExplainLegend"/>
+  <export entrypoint="reahl.component.commands" name="List" locator="reahl.dev.devshell:List"/>
+  <export entrypoint="reahl.component.commands" name="Select" locator="reahl.dev.devshell:Select"/>
+  <export entrypoint="reahl.component.commands" name="ClearSelection" locator="reahl.dev.devshell:ClearSelection"/>
+  <export entrypoint="reahl.component.commands" name="ListSelections" locator="reahl.dev.devshell:ListSelections"/>
+  <export entrypoint="reahl.component.commands" name="Save" locator="reahl.dev.devshell:Save"/>
+  <export entrypoint="reahl.component.commands" name="Read" locator="reahl.dev.devshell:Read"/>
+  <export entrypoint="reahl.component.commands" name="DeleteSelection" locator="reahl.dev.devshell:DeleteSelection"/>
+  <export entrypoint="reahl.component.commands" name="Shell" locator="reahl.dev.devshell:Shell"/>
+  <export entrypoint="reahl.component.commands" name="Setup" locator="reahl.dev.devshell:Setup"/>
+  <export entrypoint="reahl.component.commands" name="Build" locator="reahl.dev.devshell:Build"/>
+  <export entrypoint="reahl.component.commands" name="ListMissingDependencies" locator="reahl.dev.devshell:ListMissingDependencies"/>
+  <export entrypoint="reahl.component.commands" name="DebInstall" locator="reahl.dev.devshell:DebInstall"/>
+  <export entrypoint="reahl.component.commands" name="Upload" locator="reahl.dev.devshell:Upload"/>
+  <export entrypoint="reahl.component.commands" name="MarkReleased" locator="reahl.dev.devshell:MarkReleased"/>
+  <export entrypoint="reahl.component.commands" name="SubstVars" locator="reahl.dev.devshell:SubstVars"/>
+  <export entrypoint="reahl.component.commands" name="Debianise" locator="reahl.dev.devshell:Debianise"/>
+  <export entrypoint="reahl.component.commands" name="Info" locator="reahl.dev.devshell:Info"/>
 
-  <export entrypoint="reahl.dev.commands" name="ExtractMessages" locator="reahl.dev.devshell:ExtractMessages"/>
-  <export entrypoint="reahl.dev.commands" name="MergeTranslations" locator="reahl.dev.devshell:MergeTranslations"/>
-  <export entrypoint="reahl.dev.commands" name="CompileTranslations" locator="reahl.dev.devshell:CompileTranslations"/>
-  <export entrypoint="reahl.dev.commands" name="AddLocale" locator="reahl.dev.devshell:AddLocale"/>
+  <export entrypoint="reahl.component.commands" name="ExtractMessages" locator="reahl.dev.devshell:ExtractMessages"/>
+  <export entrypoint="reahl.component.commands" name="MergeTranslations" locator="reahl.dev.devshell:MergeTranslations"/>
+  <export entrypoint="reahl.component.commands" name="CompileTranslations" locator="reahl.dev.devshell:CompileTranslations"/>
+  <export entrypoint="reahl.component.commands" name="AddLocale" locator="reahl.dev.devshell:AddLocale"/>
 
-  <export entrypoint="reahl.dev.commands" name="UpdateAptRepository" locator="reahl.dev.devshell:UpdateAptRepository"/>
-  <export entrypoint="reahl.dev.commands" name="ServeSMTP" locator="reahl.dev.mailtest:ServeSMTP"/>
+  <export entrypoint="reahl.component.commands" name="UpdateAptRepository" locator="reahl.dev.devshell:UpdateAptRepository"/>
+  <export entrypoint="reahl.component.commands" name="ServeSMTP" locator="reahl.dev.mailtest:ServeSMTP"/>
 
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.dev_dev'"/>
   
   <distpackage type="wheel">
     <packageindex repository="pypi"/>

--- a/reahl-dev/.reahlproject
+++ b/reahl-dev/.reahlproject
@@ -60,8 +60,6 @@
   <export entrypoint="reahl.dev.xmlclasses" name="ExcludedPackage" locator="reahl.dev.devdomain:ExcludedPackage"/>
   <export entrypoint="reahl.dev.xmlclasses" name="TranslationPackage" locator="reahl.dev.devdomain:TranslationPackage"/>
 
-  <export entrypoint="reahl.dev.xmlclasses" name="CommandAlias" locator="reahl.dev.devdomain:CommandAlias"/>
-
   <export entrypoint="reahl.dev.xmlclasses" name="ExtraPath" locator="reahl.dev.devdomain:ExtraPath"/>
   <export entrypoint="reahl.dev.xmlclasses" name="ProjectTag" locator="reahl.dev.devdomain:ProjectTag"/>
 

--- a/reahl-dev/reahl/dev/devdomain.py
+++ b/reahl-dev/reahl/dev/devdomain.py
@@ -1325,7 +1325,7 @@ class Project(object):
         self.__init__(workspace, directory)
 
     def inflate_child(self, reader, child, tag, parent):
-        elif isinstance(child, ProjectTag):
+        if isinstance(child, ProjectTag):
             self._tags.append(child.name)
         elif isinstance(child, ProjectMetadata):
             self.metadata = child

--- a/reahl-dev/reahl/dev/devdomain.py
+++ b/reahl-dev/reahl/dev/devdomain.py
@@ -1315,7 +1315,6 @@ class Project(object):
 
         self.packages = []
         self.python_path = []
-        self.command_aliases = {}
         self._tags = []
         self.metadata = ProjectMetadata(self)
         self.source_control = SourceControlSystem(self)
@@ -1367,9 +1366,6 @@ class Project(object):
         finally:
             sys.path[:] = path
             os.chdir(cwd)
-
-    def command_for_alias(self, alias):
-        return self.command_aliases.get(alias, None)
 
     def list_missing_dependencies(self, for_development=None):
         pass

--- a/reahl-dev/reahl/dev/devdomain.py
+++ b/reahl-dev/reahl/dev/devdomain.py
@@ -876,30 +876,6 @@ class NoBasket(object):
         self.project_name = 'NO BASKET'
 
 
-
-class CommandAlias(object):
-    @classmethod
-    def get_xml_registration_info(cls):
-        return ('alias', cls, None)
-
-    def __init__(self, name, full_command):
-        self.full_command = full_command
-        self.name = name
-
-    def inflate_attributes(self, reader, attributes, parent):
-        assert 'command' in attributes, 'No command specified'
-        assert 'name' in attributes, 'No arguments specified'
-        self.__init__(attributes['name'], attributes['command'])
-
-    @property
-    def arg_list(self):
-        return shlex.split(self.full_command)[1:]
-
-    @property
-    def command(self):
-        return shlex.split(self.full_command)[0]
-
-
 class ExtraPath(object):
     @classmethod
     def get_xml_registration_info(cls):
@@ -1349,8 +1325,6 @@ class Project(object):
         self.__init__(workspace, directory)
 
     def inflate_child(self, reader, child, tag, parent):
-        if isinstance(child, CommandAlias):
-            self.command_aliases[child.name] = [child.command]+child.arg_list
         elif isinstance(child, ProjectTag):
             self._tags.append(child.name)
         elif isinstance(child, ProjectMetadata):

--- a/reahl-dev/reahl/dev/devshell.py
+++ b/reahl-dev/reahl/dev/devshell.py
@@ -288,22 +288,6 @@ class ForAllWorkspaceCommand(WorkspaceCommand):
         pass
 
 
-class AliasWorkspaceCommand(ForAllWorkspaceCommand):
-    def __init__(self, commandline, keyword):
-        super(AliasWorkspaceCommand, self).__init__(commandline)
-        self.keyword = keyword
-        self.failures = []
-
-    def function(self, project, options, args):
-        full_command = project.command_aliases.get(self.keyword, None)
-        if not full_command:
-            self.failures.append(project)
-            return -1
-        command = self.commandline.command_named(full_command[0])
-        dash_index = full_command.index('--')
-        return command.execute_one(project, options, full_command[dash_index+1:]+args)
-
-
 class Debianise(ForAllWorkspaceCommand):
     """Debianises a project."""
     keyword = 'debianise'
@@ -552,25 +536,6 @@ class AddLocale(ForAllWorkspaceCommand):
         return 0
 
 
-class WorkspaceCommandline(ReahlCommandline):
-    """The main class for invoking commands on the commandline of a development Workspace."""
-    usage_string = '[options] <command> [command options] [-- [command_argument...]]'
-    def __init__(self, options):
-        super(WorkspaceCommandline, self).__init__(options, DevShellConfig())
-
-    def execute_command(self, command, line, options, parser):
-        self.set_log_level(options.loglevel)
-        if command in self.command_names:
-            return self.command_named(command).do(line)
-
-        alias_command = AliasWorkspaceCommand(self, command)
-        retcode = alias_command.do(line)
-        if alias_command.failures:
-            print('\nThere is no command named %s\nAlso, no aliases found for it in project(s):\n' % command, file=sys.stderr)
-            print(', '.join([i.project_name for i in alias_command.failures]), file=sys.stderr)
-            self.print_usage(parser)
-            retcode = -1
-        return retcode
 
 
 

--- a/reahl-dev/reahl/dev/devshell.py
+++ b/reahl-dev/reahl/dev/devshell.py
@@ -29,7 +29,6 @@ import traceback
 import shlex
 
 from reahl.component.shelltools import Command, ReahlCommandline, Executable
-from reahl.component.config import EntryPointClassList, Configuration
 
 from reahl.dev.devdomain import Workspace, Project, ProjectList, ProjectNotFound, LocalAptRepository, SetupCommandFailed
 from reahl.dev.exceptions import StatusException, AlreadyUploadedException, \
@@ -39,10 +38,6 @@ from reahl.dev.exceptions import StatusException, AlreadyUploadedException, \
     AlreadyMarkedAsReleasedException, NotBuiltAfterLastCommitException, NotBuiltException, \
     NotAValidProjectException
 from functools import reduce
-
-
-class DevShellConfig(Configuration):
-    commands = EntryPointClassList('reahl.dev.commands', description='All commands (classes) that can be handled by the development shell')
 
 
 class WorkspaceCommand(Command):

--- a/reahl-dev/reahl/dev_dev/test_domain.py
+++ b/reahl-dev/reahl/dev_dev/test_domain.py
@@ -402,8 +402,6 @@ def test_setup_project_file_queries():
 
 <excludepackage name="this.pack2"/>
 
-<alias name="accept" command="tofu -f Piet"/>
-
 <pythonpath path="stuff"/>
 <pythonpath path="stuff2"/>
 
@@ -455,9 +453,6 @@ def test_setup_project_file_queries():
                 }
 
     assert project.entry_points_for_setup() == expected_value
-
-    assert project.command_for_alias('accept') == ['tofu', '-f', 'Piet']
-    assert project.command_for_alias('niemand') == None
 
     assert project.python_path == ['stuff','stuff2']
 

--- a/reahl-dev/reahl_dev.egg-info/SOURCES.txt
+++ b/reahl-dev/reahl_dev.egg-info/SOURCES.txt
@@ -1,4 +1,5 @@
 .bzrignore
+.reahlalias
 .reahlproject
 COPYING
 LICENSE

--- a/reahl-dev/reahl_dev.egg-info/entry_points.txt
+++ b/reahl-dev/reahl_dev.egg-info/entry_points.txt
@@ -1,7 +1,4 @@
-[console_scripts]
-reahl = reahl.dev.devshell:WorkspaceCommandline.execute_one
-
-[reahl.dev.commands]
+[reahl.component.commands]
 AddLocale = reahl.dev.devshell:AddLocale
 Build = reahl.dev.devshell:Build
 ClearSelection = reahl.dev.devshell:ClearSelection

--- a/reahl-dev/reahl_dev.egg-info/entry_points.txt
+++ b/reahl-dev/reahl_dev.egg-info/entry_points.txt
@@ -27,7 +27,6 @@ Upload = reahl.dev.devshell:Upload
 
 [reahl.dev.xmlclasses]
 ChickenProject = reahl.dev.devdomain:ChickenProject
-CommandAlias = reahl.dev.devdomain:CommandAlias
 ConfigurationSpec = reahl.dev.devdomain:ConfigurationSpec
 DebianPackage = reahl.dev.devdomain:DebianPackage
 DebianPackageMetadata = reahl.dev.devdomain:DebianPackageMetadata

--- a/reahl-doc/.reahlalias
+++ b/reahl-doc/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.doc_dev reahl.doc'

--- a/reahl-doc/.reahlproject
+++ b/reahl-doc/.reahlproject
@@ -68,8 +68,8 @@
 
   <schedule locator="reahl.doc.examples.tutorial.jobsbootstrap.jobsbootstrap:Address.clear_added_flags"/>
 
-  <export entrypoint="reahl.dev.commands" name="GetExample" locator="reahl.doc.commands:GetExample"/>
-  <export entrypoint="reahl.dev.commands" name="ListExamples" locator="reahl.doc.commands:ListExamples"/>
+  <export entrypoint="reahl.component.commands" name="GetExample" locator="reahl.doc.commands:GetExample"/>
+  <export entrypoint="reahl.component.commands" name="ListExamples" locator="reahl.doc.commands:ListExamples"/>
 
 
   <distpackage type="wheel">

--- a/reahl-doc/.reahlproject
+++ b/reahl-doc/.reahlproject
@@ -71,7 +71,6 @@
   <export entrypoint="reahl.dev.commands" name="GetExample" locator="reahl.doc.commands:GetExample"/>
   <export entrypoint="reahl.dev.commands" name="ListExamples" locator="reahl.doc.commands:ListExamples"/>
 
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.doc_dev reahl.doc'"/>
 
   <distpackage type="wheel">
     <packageindex repository="pypi"/>

--- a/reahl-doc/doc/devtools/xmlref.rst
+++ b/reahl-doc/doc/devtools/xmlref.rst
@@ -95,7 +95,7 @@ locator attribute
 <schedule>
 """"""""""
 
-  Used to indicate a function or class method to be called every time ``reahl-control runjobs``
+  Used to indicate a function or class method to be called every time ``reahl runjobs``
   is run. It requires a :ref:`locator-attribute` for the relevant function or class method.
 
 <namespace>
@@ -179,17 +179,5 @@ Development and packaging
   
   A particular `<distpackage>` may be uploaded to several different repositories, each named in a 
   `<packageindex>` element.
-
-<alias>
-"""""""
-
-  The `<alias>` element is used to define an alias for a command just for this project. The alias
-  is for a command that the `reahl` script can perform, but it may include arguments. It is useful
-  to, for example, declare ``reahl unit`` in different ways for different projects to run the
-  unit tests of each project.
-  
-  This element requires a `name` attribute -- the name that will be used to invoke the alias. It
-  also required a `command` attribute -- the full command that will be specified when invoked
-  including all arguments.
 
 

--- a/reahl-doc/reahl/doc/examples/features/access/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/features/access/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- check

--- a/reahl-doc/reahl/doc/examples/features/access/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/features/access/.reahlproject
@@ -17,6 +17,5 @@
     <class locator="reahl.doc.examples.features.access.access:Comment"/>
   </persisted>
 
-  <alias name="unit" command="setup -- check"/>
 
 </project>

--- a/reahl-doc/reahl/doc/examples/features/carousel/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/features/carousel/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- check

--- a/reahl-doc/reahl/doc/examples/features/carousel/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/features/carousel/.reahlproject
@@ -12,5 +12,4 @@
     <egg name="reahl-webdev"/>
   </deps>
 
-  <alias name="unit" command="setup -- check"/>
 </project>

--- a/reahl-doc/reahl/doc/examples/features/i18nexample/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/features/i18nexample/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- check

--- a/reahl-doc/reahl/doc/examples/features/i18nexample/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/features/i18nexample/.reahlproject
@@ -13,5 +13,4 @@
     <egg name="reahl-webdev"/>
   </deps>
 
-  <alias name="unit" command="setup -- check"/>
 </project>

--- a/reahl-doc/reahl/doc/examples/features/layout/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/features/layout/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- check

--- a/reahl-doc/reahl/doc/examples/features/layout/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/features/layout/.reahlproject
@@ -13,5 +13,4 @@
     <egg name="reahl-webdev"/>
   </deps>
 
-  <alias name="unit" command="setup -- check"/>
 </project>

--- a/reahl-doc/reahl/doc/examples/features/pageflow/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/features/pageflow/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- check

--- a/reahl-doc/reahl/doc/examples/features/pageflow/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/features/pageflow/.reahlproject
@@ -12,5 +12,4 @@
     <egg name="reahl-webdev"/>
   </deps>
 
-  <alias name="unit" command="setup -- check"/>
 </project>

--- a/reahl-doc/reahl/doc/examples/features/persistence/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/features/persistence/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- check

--- a/reahl-doc/reahl/doc/examples/features/persistence/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/features/persistence/.reahlproject
@@ -17,5 +17,4 @@
     <class locator="reahl.doc.examples.features.persistence.persistence:Comment"/>
   </persisted>
 
-  <alias name="unit" command="setup -- check"/>
 </project>

--- a/reahl-doc/reahl/doc/examples/features/tabbedpanel/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/features/tabbedpanel/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- check

--- a/reahl-doc/reahl/doc/examples/features/tabbedpanel/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/features/tabbedpanel/.reahlproject
@@ -12,6 +12,5 @@
     <egg name="reahl-webdev"/>
   </deps>
 
-  <alias name="unit" command="setup -- check"/>
 
 </project>

--- a/reahl-doc/reahl/doc/examples/features/validation/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/features/validation/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- check

--- a/reahl-doc/reahl/doc/examples/features/validation/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/features/validation/.reahlproject
@@ -12,5 +12,4 @@
     <egg name="reahl-webdev"/>
   </deps>
 
-  <alias name="unit" command="setup -- check"/>
 </project>

--- a/reahl-doc/reahl/doc/examples/tutorial/access1bootstrap/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/tutorial/access1bootstrap/.reahlalias
@@ -1,0 +1,2 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.access1bootstrap.access1bootstrap_dev'
+  demosetup setup -- -q pytest --addopts '-s -o python_functions=demo_setup --pyargs reahl.doc.examples.tutorial.access1bootstrap.access1bootstrap_dev'

--- a/reahl-doc/reahl/doc/examples/tutorial/access1bootstrap/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/tutorial/access1bootstrap/.reahlproject
@@ -23,7 +23,5 @@
     <class locator="reahl.doc.examples.tutorial.access1bootstrap.access1bootstrap:Address"/>
   </persisted>
   
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.access1bootstrap.access1bootstrap_dev'"/>
-  <alias name="demosetup" command="setup -- -q pytest --addopts '-s -o python_functions=demo_setup --pyargs reahl.doc.examples.tutorial.access1bootstrap.access1bootstrap_dev'"/>
 
 </project>

--- a/reahl-doc/reahl/doc/examples/tutorial/access2bootstrap/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/tutorial/access2bootstrap/.reahlalias
@@ -1,0 +1,2 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.access2bootstrap.access2bootstrap_dev'
+  demosetup setup -- -q pytest --addopts '-s -o python_functions=demo_setup --pyargs reahl.doc.examples.tutorial.access2bootstrap.access2bootstrap_dev'

--- a/reahl-doc/reahl/doc/examples/tutorial/access2bootstrap/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/tutorial/access2bootstrap/.reahlproject
@@ -25,7 +25,5 @@
     <class locator="reahl.doc.examples.tutorial.access2bootstrap.access2bootstrap:Address"/>
   </persisted>
   
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.access2bootstrap.access2bootstrap_dev'"/>
-  <alias name="demosetup" command="setup -- -q pytest --addopts '-s -o python_functions=demo_setup --pyargs reahl.doc.examples.tutorial.access2bootstrap.access2bootstrap_dev'"/>
 
 </project>

--- a/reahl-doc/reahl/doc/examples/tutorial/accessbootstrap/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/tutorial/accessbootstrap/.reahlalias
@@ -1,0 +1,2 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.accessbootstrap.accessbootstrap_dev'
+  demosetup setup -- -q pytest --addopts '-s -o python_functions=demo_setup --pyargs reahl.doc.examples.tutorial.accessbootstrap.accessbootstrap_dev'

--- a/reahl-doc/reahl/doc/examples/tutorial/accessbootstrap/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/tutorial/accessbootstrap/.reahlproject
@@ -25,8 +25,6 @@
     <class locator="reahl.doc.examples.tutorial.accessbootstrap.accessbootstrap:Address"/>
   </persisted>
   
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.accessbootstrap.accessbootstrap_dev'"/>
-  <alias name="demosetup" command="setup -- -q pytest --addopts '-s -o python_functions=demo_setup --pyargs reahl.doc.examples.tutorial.accessbootstrap.accessbootstrap_dev'"/>
 
 
 </project>

--- a/reahl-doc/reahl/doc/examples/tutorial/addressbook1/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/tutorial/addressbook1/.reahlalias
@@ -1,0 +1,3 @@
+  unit setup -- check
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.addressbook1.addressbook1_dev'
+  demosetup setup -- -q pytest --addopts '-s -o python_functions=demo_setup --pyargs reahl.doc.examples.tutorial.addressbook1.addressbook1_dev'

--- a/reahl-doc/reahl/doc/examples/tutorial/addressbook1/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/tutorial/addressbook1/.reahlproject
@@ -5,10 +5,7 @@
     <egg name="reahl-sqlalchemysupport"/>
     <egg name="reahl-web-declarative"/>
   </deps>
-  <alias name="unit" command="setup -- check"/>
   <persisted>
     <class locator="reahl.doc.examples.tutorial.addressbook1.addressbook1:Address"/>
   </persisted>
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.addressbook1.addressbook1_dev'"/>
-  <alias name="demosetup" command="setup -- -q pytest --addopts '-s -o python_functions=demo_setup --pyargs reahl.doc.examples.tutorial.addressbook1.addressbook1_dev'"/>
 </project>

--- a/reahl-doc/reahl/doc/examples/tutorial/addressbook2/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/tutorial/addressbook2/.reahlalias
@@ -1,0 +1,3 @@
+  unit setup -- check
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.addressbook2.addressbook2_dev'
+  demosetup setup -- -q pytest --addopts '-s -o python_functions=demo_setup --pyargs reahl.doc.examples.tutorial.addressbook2.addressbook2_dev'

--- a/reahl-doc/reahl/doc/examples/tutorial/addressbook2/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/tutorial/addressbook2/.reahlproject
@@ -5,10 +5,7 @@
     <egg name="reahl-sqlalchemysupport"/>
     <egg name="reahl-web-declarative"/>
   </deps>
-  <alias name="unit" command="setup -- check"/>
   <persisted>
     <class locator="reahl.doc.examples.tutorial.addressbook2.addressbook2:Address"/>
   </persisted>
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.addressbook2.addressbook2_dev'"/>
-  <alias name="demosetup" command="setup -- -q pytest --addopts '-s -o python_functions=demo_setup --pyargs reahl.doc.examples.tutorial.addressbook2.addressbook2_dev'"/>
 </project>

--- a/reahl-doc/reahl/doc/examples/tutorial/addressbook2bootstrap/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/tutorial/addressbook2bootstrap/.reahlalias
@@ -1,0 +1,2 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.addressbook2bootstrap.addressbook2bootstrap_dev'
+  demosetup setup -- -q pytest --addopts '-s -o python_functions=demo_setup --pyargs reahl.doc.examples.tutorial.addressbook2bootstrap.addressbook2bootstrap_dev'

--- a/reahl-doc/reahl/doc/examples/tutorial/addressbook2bootstrap/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/tutorial/addressbook2bootstrap/.reahlproject
@@ -22,7 +22,5 @@
     <class locator="reahl.doc.examples.tutorial.addressbook2bootstrap.addressbook2bootstrap:Address"/>
   </persisted>
   
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.addressbook2bootstrap.addressbook2bootstrap_dev'"/>
-  <alias name="demosetup" command="setup -- -q pytest --addopts '-s -o python_functions=demo_setup --pyargs reahl.doc.examples.tutorial.addressbook2bootstrap.addressbook2bootstrap_dev'"/>
 
 </project>

--- a/reahl-doc/reahl/doc/examples/tutorial/addresslist/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/tutorial/addresslist/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- check

--- a/reahl-doc/reahl/doc/examples/tutorial/addresslist/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/tutorial/addresslist/.reahlproject
@@ -5,5 +5,4 @@
     <egg name="reahl-sqlalchemysupport"/>
     <egg name="reahl-web-declarative"/>
   </deps>
-  <alias name="unit" command="setup -- check"/>
 </project>

--- a/reahl-doc/reahl/doc/examples/tutorial/ajaxbootstrap/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/tutorial/ajaxbootstrap/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.ajaxbootstrap.ajaxbootstrap_dev'

--- a/reahl-doc/reahl/doc/examples/tutorial/ajaxbootstrap/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/tutorial/ajaxbootstrap/.reahlproject
@@ -18,6 +18,5 @@
     <egg name="reahl-webdev"/>
   </deps>
 
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.ajaxbootstrap.ajaxbootstrap_dev'"/>
 
 </project>

--- a/reahl-doc/reahl/doc/examples/tutorial/bootstrapgrids/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/tutorial/bootstrapgrids/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- check

--- a/reahl-doc/reahl/doc/examples/tutorial/bootstrapgrids/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/tutorial/bootstrapgrids/.reahlproject
@@ -5,5 +5,4 @@
     <egg name="reahl-sqlalchemysupport"/>
     <egg name="reahl-web-declarative"/>
   </deps>
-  <alias name="unit" command="setup -- check"/>
 </project>

--- a/reahl-doc/reahl/doc/examples/tutorial/componentconfigbootstrap/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/tutorial/componentconfigbootstrap/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.componentconfigbootstrap.componentconfigbootstrap_dev'

--- a/reahl-doc/reahl/doc/examples/tutorial/componentconfigbootstrap/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/tutorial/componentconfigbootstrap/.reahlproject
@@ -26,6 +26,5 @@
     <class locator="reahl.doc.examples.tutorial.componentconfigbootstrap.componentconfigbootstrap:Address"/>
   </persisted>
   
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.componentconfigbootstrap.componentconfigbootstrap_dev'"/>
 
 </project>

--- a/reahl-doc/reahl/doc/examples/tutorial/datatablebootstrap/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/tutorial/datatablebootstrap/.reahlalias
@@ -1,0 +1,2 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.datatablebootstrap.datatablebootstrap_dev'
+  demosetup setup -- -q pytest --addopts '-s -o python_functions=demo_setup --pyargs reahl.doc.examples.tutorial.datatablebootstrap.datatablebootstrap_dev'

--- a/reahl-doc/reahl/doc/examples/tutorial/datatablebootstrap/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/tutorial/datatablebootstrap/.reahlproject
@@ -22,7 +22,5 @@
     <class locator="reahl.doc.examples.tutorial.datatablebootstrap.datatablebootstrap:Address"/>
   </persisted>
   
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.datatablebootstrap.datatablebootstrap_dev'"/>
-  <alias name="demosetup" command="setup -- -q pytest --addopts '-s -o python_functions=demo_setup --pyargs reahl.doc.examples.tutorial.datatablebootstrap.datatablebootstrap_dev'"/>
 
 </project>

--- a/reahl-doc/reahl/doc/examples/tutorial/hello/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/tutorial/hello/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- check

--- a/reahl-doc/reahl/doc/examples/tutorial/hello/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/tutorial/hello/.reahlproject
@@ -5,5 +5,4 @@
     <egg name="reahl-sqlalchemysupport"/>
     <egg name="reahl-web-declarative"/>
   </deps>
-  <alias name="unit" command="setup -- check"/>
 </project>

--- a/reahl-doc/reahl/doc/examples/tutorial/helloapache/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/tutorial/helloapache/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- checkx

--- a/reahl-doc/reahl/doc/examples/tutorial/helloapache/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/tutorial/helloapache/.reahlproject
@@ -6,7 +6,6 @@
     <egg name="reahl-web-declarative"/>
   </deps>
 
-  <alias name="unit" command="setup -- check"/>x
 
   <!-- packaging -->
   <distpackage type="wheel">

--- a/reahl-doc/reahl/doc/examples/tutorial/hellonginx/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/tutorial/hellonginx/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- check

--- a/reahl-doc/reahl/doc/examples/tutorial/hellonginx/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/tutorial/hellonginx/.reahlproject
@@ -6,7 +6,6 @@
     <egg name="reahl-web-declarative"/>
   </deps>
 
-  <alias name="unit" command="setup -- check"/>
 
   <!-- packaging -->
   <distpackage type="wheel">

--- a/reahl-doc/reahl/doc/examples/tutorial/i18nexamplebootstrap/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/tutorial/i18nexamplebootstrap/.reahlalias
@@ -1,0 +1,2 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.i18nexamplebootstrap.i18nexamplebootstrap_dev'
+  demosetup setup -- -q pytest --addopts '-s -o python_functions=demo_setup --pyargs reahl.doc.examples.tutorial.i18nexamplebootstrap.i18nexamplebootstrap_dev'

--- a/reahl-doc/reahl/doc/examples/tutorial/i18nexamplebootstrap/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/tutorial/i18nexamplebootstrap/.reahlproject
@@ -25,7 +25,5 @@
     <class locator="reahl.doc.examples.tutorial.i18nexamplebootstrap.i18nexamplebootstrap:Address"/>
   </persisted>
   
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.i18nexamplebootstrap.i18nexamplebootstrap_dev'"/>
-  <alias name="demosetup" command="setup -- -q pytest --addopts '-s -o python_functions=demo_setup --pyargs reahl.doc.examples.tutorial.i18nexamplebootstrap.i18nexamplebootstrap_dev'"/>
 
 </project>

--- a/reahl-doc/reahl/doc/examples/tutorial/jobsbootstrap/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/tutorial/jobsbootstrap/.reahlalias
@@ -1,0 +1,2 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.jobsbootstrap.jobsbootstrap_dev'
+  demosetup setup -- -q pytest --addopts '-s -o python_functions=demo_setup --pyargs reahl.doc.examples.tutorial.jobsbootstrap.jobsbootstrap_dev'

--- a/reahl-doc/reahl/doc/examples/tutorial/jobsbootstrap/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/tutorial/jobsbootstrap/.reahlproject
@@ -24,7 +24,5 @@
 
   <schedule locator="reahl.doc.examples.tutorial.jobsbootstrap.jobsbootstrap:Address.clear_added_flags"/>
 
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.jobsbootstrap.jobsbootstrap_dev'"/>
-  <alias name="demosetup" command="setup -- -q pytest --addopts '-s -o python_functions=demo_setup --pyargs reahl.doc.examples.tutorial.jobsbootstrap.jobsbootstrap_dev'"/>
 
 </project>

--- a/reahl-doc/reahl/doc/examples/tutorial/login1bootstrap/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/tutorial/login1bootstrap/.reahlalias
@@ -1,0 +1,2 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.login1bootstrap.login1bootstrap_dev'
+  demosetup setup -- -q pytest --addopts '-s -o python_functions=demo_setup --pyargs reahl.doc.examples.tutorial.login1bootstrap.login1bootstrap_dev'

--- a/reahl-doc/reahl/doc/examples/tutorial/login1bootstrap/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/tutorial/login1bootstrap/.reahlproject
@@ -19,7 +19,5 @@
     <egg name="reahl-webdev"/>
   </deps>
 
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.login1bootstrap.login1bootstrap_dev'"/>
-  <alias name="demosetup" command="setup -- -q pytest --addopts '-s -o python_functions=demo_setup --pyargs reahl.doc.examples.tutorial.login1bootstrap.login1bootstrap_dev'"/>
 
 </project>

--- a/reahl-doc/reahl/doc/examples/tutorial/login2bootstrap/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/tutorial/login2bootstrap/.reahlalias
@@ -1,0 +1,2 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.login2bootstrap.login2bootstrap_dev'
+  demosetup setup -- -q pytest --addopts '-s -o python_functions=demo_setup --pyargs reahl.doc.examples.tutorial.login2bootstrap.login2bootstrap_dev'

--- a/reahl-doc/reahl/doc/examples/tutorial/login2bootstrap/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/tutorial/login2bootstrap/.reahlproject
@@ -20,7 +20,5 @@
     <egg name="reahl-webdev"/>
   </deps>
 
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.login2bootstrap.login2bootstrap_dev'"/>
-  <alias name="demosetup" command="setup -- -q pytest --addopts '-s -o python_functions=demo_setup --pyargs reahl.doc.examples.tutorial.login2bootstrap.login2bootstrap_dev'"/>
 
 </project>

--- a/reahl-doc/reahl/doc/examples/tutorial/migrationexamplebootstrap/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/tutorial/migrationexamplebootstrap/.reahlalias
@@ -1,0 +1,2 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.migrationexamplebootstrap.migrationexamplebootstrap_dev'
+  demosetup setup -- -q pytest --addopts '-s -o python_functions=demo_setup --pyargs reahl.doc.examples.tutorial.migrationexamplebootstrap.migrationexamplebootstrap_dev'

--- a/reahl-doc/reahl/doc/examples/tutorial/migrationexamplebootstrap/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/tutorial/migrationexamplebootstrap/.reahlproject
@@ -35,7 +35,5 @@
     <class locator="reahl.doc.examples.tutorial.migrationexamplebootstrap.migrationexamplebootstrap:AddDate"/>
   </migrations>
 
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.migrationexamplebootstrap.migrationexamplebootstrap_dev'"/>
-  <alias name="demosetup" command="setup -- -q pytest --addopts '-s -o python_functions=demo_setup --pyargs reahl.doc.examples.tutorial.migrationexamplebootstrap.migrationexamplebootstrap_dev'"/>
 
 </project>

--- a/reahl-doc/reahl/doc/examples/tutorial/migrationexamplebootstrap/migrationexamplebootstrap_dev/test.sh
+++ b/reahl-doc/reahl/doc/examples/tutorial/migrationexamplebootstrap/migrationexamplebootstrap_dev/test.sh
@@ -19,9 +19,9 @@ function fail() {
 }
 
 reahl setup -- develop -N
-reahl-control dropdb etc
-reahl-control createdb etc
-reahl-control createdbtables etc
+reahl dropdb etc
+reahl createdb etc
+reahl createdbtables etc
 
 $( version_is "0.0" ) || fail "Version 0.0 expected"
 $( ! schema_is_new ) || fail "Old schema expected"
@@ -31,7 +31,7 @@ sed -i 's|<info name="version">0.0</info>|<info name="version">0.1</info>|g' .re
 sed -Ei 's|^#( *)added_date|\1added_date|g' migrationexamplebootstrap.py
 sed -Ei 's|^(.*)TODO(.*)|#\1TODO\2|g' migrationexamplebootstrap.py
 reahl setup -- develop -N
-reahl-control migratedb etc
+reahl migratedb etc
 
 $( version_is "0.1" ) || fail "Version 0.1 expected"
 $( schema_is_new ) || fail "New schema expected"

--- a/reahl-doc/reahl/doc/examples/tutorial/pageflow1/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/tutorial/pageflow1/.reahlalias
@@ -1,0 +1,3 @@
+  unit setup -- check
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.pageflow1.pageflow1_dev'
+  demosetup setup -- -q pytest --addopts '-s -o python_functions=demo_setup --pyargs reahl.doc.examples.tutorial.pageflow1.pageflow1_dev'

--- a/reahl-doc/reahl/doc/examples/tutorial/pageflow1/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/tutorial/pageflow1/.reahlproject
@@ -5,10 +5,7 @@
     <egg name="reahl-sqlalchemysupport"/>
     <egg name="reahl-web-declarative"/>
   </deps>
-  <alias name="unit" command="setup -- check"/>
   <persisted>
     <class locator="reahl.doc.examples.tutorial.pageflow1.pageflow1:Address"/>
   </persisted>
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.pageflow1.pageflow1_dev'"/>
-  <alias name="demosetup" command="setup -- -q pytest --addopts '-s -o python_functions=demo_setup --pyargs reahl.doc.examples.tutorial.pageflow1.pageflow1_dev'"/>
 </project>

--- a/reahl-doc/reahl/doc/examples/tutorial/pagelayout/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/tutorial/pagelayout/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- check

--- a/reahl-doc/reahl/doc/examples/tutorial/pagelayout/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/tutorial/pagelayout/.reahlproject
@@ -5,5 +5,4 @@
     <egg name="reahl-sqlalchemysupport"/>
     <egg name="reahl-web-declarative"/>
   </deps>
-  <alias name="unit" command="setup -- check"/>
 </project>

--- a/reahl-doc/reahl/doc/examples/tutorial/pagerbootstrap/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/tutorial/pagerbootstrap/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.pagerbootstrap.pagerbootstrap_dev'

--- a/reahl-doc/reahl/doc/examples/tutorial/pagerbootstrap/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/tutorial/pagerbootstrap/.reahlproject
@@ -17,6 +17,5 @@
     <egg name="reahl-webdev"/>
   </deps>
 
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.pagerbootstrap.pagerbootstrap_dev'"/>
 
 </project>

--- a/reahl-doc/reahl/doc/examples/tutorial/parameterised1/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/tutorial/parameterised1/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.parameterised1.parameterised1_dev'

--- a/reahl-doc/reahl/doc/examples/tutorial/parameterised1/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/tutorial/parameterised1/.reahlproject
@@ -22,6 +22,5 @@
     <class locator="reahl.doc.examples.tutorial.parameterised1.parameterised1:Address"/>
   </persisted>
   
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.parameterised1.parameterised1_dev'"/>
   
 </project>

--- a/reahl-doc/reahl/doc/examples/tutorial/parameterised2/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/tutorial/parameterised2/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.parameterised2.parameterised2_dev'

--- a/reahl-doc/reahl/doc/examples/tutorial/parameterised2/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/tutorial/parameterised2/.reahlproject
@@ -22,6 +22,5 @@
     <class locator="reahl.doc.examples.tutorial.parameterised2.parameterised2:Address"/>
   </persisted>
   
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.parameterised2.parameterised2_dev'"/>
   
 </project>

--- a/reahl-doc/reahl/doc/examples/tutorial/sessionscopebootstrap/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/tutorial/sessionscopebootstrap/.reahlalias
@@ -1,0 +1,2 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.sessionscopebootstrap.sessionscopebootstrap_dev'
+  demosetup setup -- -q pytest --addopts '-s -o python_functions=demo_setup --pyargs reahl.doc.examples.tutorial.sessionscopebootstrap.sessionscopebootstrap_dev'

--- a/reahl-doc/reahl/doc/examples/tutorial/sessionscopebootstrap/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/tutorial/sessionscopebootstrap/.reahlproject
@@ -23,8 +23,6 @@
     <class locator="reahl.doc.examples.tutorial.sessionscopebootstrap.sessionscopebootstrap:LoginSession"/>
   </persisted>
   
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.sessionscopebootstrap.sessionscopebootstrap_dev'"/>
-  <alias name="demosetup" command="setup -- -q pytest --addopts '-s -o python_functions=demo_setup --pyargs reahl.doc.examples.tutorial.sessionscopebootstrap.sessionscopebootstrap_dev'"/>
 
   
 </project>

--- a/reahl-doc/reahl/doc/examples/tutorial/slots/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/tutorial/slots/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.slots.slots_dev'

--- a/reahl-doc/reahl/doc/examples/tutorial/slots/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/tutorial/slots/.reahlproject
@@ -17,6 +17,5 @@
     <egg name="reahl-webdev"/>
   </deps>
 
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.slots.slots_dev'"/>
 
 </project>

--- a/reahl-doc/reahl/doc/examples/tutorial/tablebootstrap/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/tutorial/tablebootstrap/.reahlalias
@@ -1,0 +1,2 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.tablebootstrap.tablebootstrap_dev'
+  demosetup setup -- -q pytest --addopts '-s -o python_functions=demo_setup --pyargs reahl.doc.examples.tutorial.tablebootstrap.tablebootstrap_dev'

--- a/reahl-doc/reahl/doc/examples/tutorial/tablebootstrap/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/tutorial/tablebootstrap/.reahlproject
@@ -22,8 +22,6 @@
     <class locator="reahl.doc.examples.tutorial.tablebootstrap.tablebootstrap:Address"/>
   </persisted>
   
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.tutorial.tablebootstrap.tablebootstrap_dev'"/>
-  <alias name="demosetup" command="setup -- -q pytest --addopts '-s -o python_functions=demo_setup --pyargs reahl.doc.examples.tutorial.tablebootstrap.tablebootstrap_dev'"/>
 
 
 </project>

--- a/reahl-doc/reahl/doc/examples/web/basichtmlinputs/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/web/basichtmlinputs/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.web.basichtmlinputs.basichtmlinputs_dev'

--- a/reahl-doc/reahl/doc/examples/web/basichtmlinputs/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/web/basichtmlinputs/.reahlproject
@@ -17,6 +17,5 @@
     <egg name="reahl-webdev"/>
   </deps>
 
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.web.basichtmlinputs.basichtmlinputs_dev'"/>
 
 </project>

--- a/reahl-doc/reahl/doc/examples/web/basichtmlwidgets/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/web/basichtmlwidgets/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.web.basichtmlwidgets.basichtmlinputs_dev'

--- a/reahl-doc/reahl/doc/examples/web/basichtmlwidgets/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/web/basichtmlwidgets/.reahlproject
@@ -17,6 +17,5 @@
     <egg name="reahl-webdev"/>
   </deps>
 
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.web.basichtmlwidgets.basichtmlinputs_dev'"/>
 
 </project>

--- a/reahl-doc/reahl/doc/examples/web/fileupload/.reahlalias
+++ b/reahl-doc/reahl/doc/examples/web/fileupload/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.web.fileupload.basichtmlinputs_dev'

--- a/reahl-doc/reahl/doc/examples/web/fileupload/.reahlproject
+++ b/reahl-doc/reahl/doc/examples/web/fileupload/.reahlproject
@@ -22,6 +22,5 @@
     <class locator="reahl.doc.examples.web.fileupload.fileupload:AttachedFile"/>
   </persisted>
 
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.doc.examples.web.fileupload.basichtmlinputs_dev'"/>
 
 </project>

--- a/reahl-domain/.reahlalias
+++ b/reahl-domain/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.domain_dev'

--- a/reahl-domain/.reahlproject
+++ b/reahl-domain/.reahlproject
@@ -53,7 +53,6 @@
       <class locator="reahl.domain.migrations:AddLoginSession"/>
   </migrations>
 
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.domain_dev'"/>
 
   <distpackage type="wheel">
     <packageindex repository="pypi"/>

--- a/reahl-domainui/.reahlalias
+++ b/reahl-domainui/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.domainui_dev'

--- a/reahl-domainui/.reahlproject
+++ b/reahl-domainui/.reahlproject
@@ -32,7 +32,6 @@
   
   <export entrypoint="reahl.workflowui.task_widgets" name="bootstrap.TaskWidget" locator="reahl.domainui.bootstrap.workflow:TaskWidget"/>
 
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.domainui_dev'"/>
 
   <distpackage type="wheel">
     <packageindex repository="pypi"/>

--- a/reahl-mailutil/.reahlalias
+++ b/reahl-mailutil/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.mailutil_dev'

--- a/reahl-mailutil/.reahlproject
+++ b/reahl-mailutil/.reahlproject
@@ -22,7 +22,6 @@
     <egg name="reahl-stubble"/>
   </deps>
 
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.mailutil_dev'"/>
 
   <distpackage type="wheel">
     <packageindex repository="pypi"/>

--- a/reahl-postgresqlsupport/.reahlalias
+++ b/reahl-postgresqlsupport/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- check

--- a/reahl-postgresqlsupport/.reahlproject
+++ b/reahl-postgresqlsupport/.reahlproject
@@ -19,7 +19,6 @@
 
   <export entrypoint="reahl.component.databasecontrols" name="PostgresqlControl" locator="reahl.postgresqlsupport:PostgresqlControl"/>
 
-  <alias name="unit" command="setup -- check"/>
 
   <distpackage type="wheel">
     <packageindex repository="pypi"/>

--- a/reahl-sqlalchemysupport/.reahlalias
+++ b/reahl-sqlalchemysupport/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.sqlalchemysupport_dev'

--- a/reahl-sqlalchemysupport/.reahlproject
+++ b/reahl-sqlalchemysupport/.reahlproject
@@ -33,7 +33,6 @@
     <class locator="reahl.sqlalchemysupport.elixirmigration:ElixirToDeclarativeSqlAlchemySupportChanges"/>
   </migrations>
 
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.sqlalchemysupport_dev'"/>
 
   <distpackage type="wheel">
     <packageindex repository="pypi"/>

--- a/reahl-sqlitesupport/.reahlalias
+++ b/reahl-sqlitesupport/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- check

--- a/reahl-sqlitesupport/.reahlproject
+++ b/reahl-sqlitesupport/.reahlproject
@@ -18,7 +18,6 @@
 
   <export entrypoint="reahl.component.databasecontrols" name="SQLiteControl" locator="reahl.sqlitesupport:SQLiteControl"/>
 
-  <alias name="unit" command="setup -- check"/>
 
   <distpackage type="wheel">
     <packageindex repository="pypi"/>

--- a/reahl-stubble/.reahlalias
+++ b/reahl-stubble/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.stubble_dev'

--- a/reahl-stubble/.reahlproject
+++ b/reahl-stubble/.reahlproject
@@ -17,7 +17,6 @@
     <thirdpartyegg name="pytest" minversion="3.0" maxversion="3.9999"/>
   </deps>
 
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.stubble_dev'"/>
 
   <distpackage type="wheel">
     <packageindex repository="pypi"/>

--- a/reahl-tofu/.reahlalias
+++ b/reahl-tofu/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.tofu_dev'

--- a/reahl-tofu/.reahlproject
+++ b/reahl-tofu/.reahlproject
@@ -18,7 +18,6 @@
     <thirdpartyegg name="pytest" minversion="3.0" maxversion="3.9999"/>
   </deps>
 
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.tofu_dev'"/>
   
   <distpackage type="wheel">
     <packageindex repository="pypi"/>

--- a/reahl-web-declarative/.reahlalias
+++ b/reahl-web-declarative/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.webdeclarative_dev'

--- a/reahl-web-declarative/.reahlproject
+++ b/reahl-web-declarative/.reahlproject
@@ -44,7 +44,6 @@
     <class locator="reahl.webdeclarative.migrations:AllowNullUserInputValue"/>
   </migrations>
 
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.webdeclarative_dev'"/>
   
   <distpackage type="wheel">
     <packageindex repository="pypi"/>

--- a/reahl-web/.reahlalias
+++ b/reahl-web/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.web_dev'

--- a/reahl-web/.reahlproject
+++ b/reahl-web/.reahlproject
@@ -39,7 +39,6 @@
   <persisted>
   </persisted>
 
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.web_dev'"/>
 
   <distpackage type="wheel">
     <packageindex repository="pypi"/>

--- a/reahl-webdev/.reahlalias
+++ b/reahl-webdev/.reahlalias
@@ -1,0 +1,1 @@
+  unit setup -- -q pytest --addopts '-s --pyargs reahl.webdev_dev'

--- a/reahl-webdev/.reahlproject
+++ b/reahl-webdev/.reahlproject
@@ -36,7 +36,6 @@
 
   <export entrypoint="reahl.dev.commands" name="ServeCurrentProject" locator="reahl.webdev.commands:ServeCurrentProject"/>
 
-  <alias name="unit" command="setup -- -q pytest --addopts '-s --pyargs reahl.webdev_dev'"/>
 
   <distpackage type="wheel">
     <packageindex repository="pypi"/>

--- a/reahl-webdev/.reahlproject
+++ b/reahl-webdev/.reahlproject
@@ -34,7 +34,7 @@
     <thirdpartyegg name="pillow" minversion="2.5" maxversion="2.5.999"/>
   </extras>
 
-  <export entrypoint="reahl.dev.commands" name="ServeCurrentProject" locator="reahl.webdev.commands:ServeCurrentProject"/>
+  <export entrypoint="reahl.component.commands" name="ServeCurrentProject" locator="reahl.webdev.commands:ServeCurrentProject"/>
 
 
   <distpackage type="wheel">

--- a/scripts/installsite-nginx.sh
+++ b/scripts/installsite-nginx.sh
@@ -26,7 +26,7 @@ pip install --no-index -f file:///home/craig/develop/.reahlworkspace/dist-egg/ h
 
 su - www-data
 . /usr/local/hellonginx/virtualenv/bin/activate
-reahl-control createdbtables /etc/reahl.d/hellonginx
+reahl createdbtables /etc/reahl.d/hellonginx
 
 exit
 

--- a/scripts/installsite.sh
+++ b/scripts/installsite.sh
@@ -18,7 +18,7 @@ pip install --no-index -f file:///home/craig/develop/.reahlworkspace/dist-egg/ h
 
 su - www-data
 source /usr/local/helloapache/virtualenv/bin/activate
-reahl-control createdbtables /etc/reahl.d/helloapache
+reahl createdbtables /etc/reahl.d/helloapache
 
 exit
 


### PR DESCRIPTION
This merges the "reahl" and "reahl-control" into just one command.  (Fixes #83 )

The original "reahl" and "reahl-control" subcommands are all published under a single entry point "reahl.component.commands". The new single "reahl" command pics all of them up from there. Hence, the new "reahl" command will have all the old commands, but exactly which commands will be available depends upon what you have installed. If you have only installed reahl-component, you will only have the prod stuff.

In order to be able to do this, the "Alias" mechanism has been removed from the .reahlproject and made into a more general concept which is not dependent on the reahl-dev stuff (such as the idea of a project). You can save aliasses for a command in ~/.reahlalias of $(PWD)/.reahlalias in text format.

"reahl" will search both of those files when running, hence you can save some aliasses as part of a project or you can save aliases in your home dir for convenience.

