### PR TITLE
Created a command to duplicate old sitecopy functionality

### DIFF
--- a/reahl-component/reahl/component/exceptions.py
+++ b/reahl-component/reahl/component/exceptions.py
@@ -33,12 +33,15 @@ class DomainException(Exception):
     """Any exception indicating an application-specific error condition that 
        should be communicated to a user.
 
-       :param commit: Set to True to indicate that the current database transaction 
-                      should be committed. By default transactions are rolled back
-                      when a DomainException is raised.
+       :keyword commit: Set to True to indicate that the current database transaction 
+                        should be committed. By default transactions are rolled back
+                        when a DomainException is raised.
+       :keyword message: Optional error message.
     """
-    def __init__(self, commit=False):
+    def __init__(self, commit=False, message=None):
+        super(DomainException, self).__init__(message)
         self.commit = commit
+        self.message = message
 
 #    __hash__ = None
 #    def __eq__(self, other):
@@ -46,10 +49,10 @@ class DomainException(Exception):
 #        return isinstance(other, self.__class__) and self.commit == other.commit
     
     def __reduce__(self):
-        return (self.__class__, (self.commit,))
+        return (self.__class__, (self.commit, self.message))
     
     def as_user_message(self):
-        return _('An error occurred: %s' % self.__class__.__name__)
+        return self.message if self.message else _('An error occurred: %s' % self.__class__.__name__)
 
 
 class AccessRestricted(Exception):

--- a/reahl-component/reahl/component/shelltools.py
+++ b/reahl-component/reahl/component/shelltools.py
@@ -32,6 +32,8 @@ import textwrap
 import inspect
 
 from reahl.component.config import Configuration, EntryPointClassList
+from reahl.component.exceptions import DomainException
+
 
 class ExecutableNotInstalledException(Exception):
     def __init__(self, executable_name):
@@ -200,7 +202,12 @@ class ReahlCommandline(CompositeCommand):
     @classmethod
     def execute_one(cls):
         """The entry point for running command from the commandline."""
-        exit(cls(sys.argv[0]).do(sys.argv[1:]))
+        try:
+            result = cls(sys.argv[0]).do(sys.argv[1:])
+        except DomainException as ex:
+            print('Error: %s' % ex, file=sys.stderr)
+            result = 1
+        exit(result)
 
     @property
     def aliasses(self):

--- a/reahl-webdev/.reahlproject
+++ b/reahl-webdev/.reahlproject
@@ -35,6 +35,7 @@
   </extras>
 
   <export entrypoint="reahl.component.commands" name="ServeCurrentProject" locator="reahl.webdev.commands:ServeCurrentProject"/>
+  <export entrypoint="reahl.component.commands" name="SyncFiles" locator="reahl.webdev.commands:SyncFiles"/>
 
 
   <distpackage type="wheel">


### PR DESCRIPTION
We used to use make-lib to generate makefiles with functionality to invoke sitecopy to sync static files to a remote machine. This adds "reahl syncfiles" command that does the same.