### PR TITLE
rather using os.path.expandvars(~) to get user home dir

### DIFF
--- a/reahl-doc/reahl/doc/examples/tutorial/helloanywhere/helloanywherewsgi.py
+++ b/reahl-doc/reahl/doc/examples/tutorial/helloanywhere/helloanywherewsgi.py
@@ -2,6 +2,6 @@ from __future__ import print_function, unicode_literals, absolute_import, divisi
 
 import os
 from reahl.web.fw import ReahlWSGIApplication
-application = ReahlWSGIApplication.from_directory('%s/etc' % os.environ['HOME'])
+application = ReahlWSGIApplication.from_directory('%s/etc' % os.path.expanduser('~'))
 application.start()
 

--- a/reahl-doc/reahl/doc/examples/tutorial/helloanywhere/prod/etc/reahl.config.py
+++ b/reahl-doc/reahl/doc/examples/tutorial/helloanywhere/prod/etc/reahl.config.py
@@ -6,7 +6,7 @@ reahlsystem.root_egg = 'helloanywhere'
 reahlsystem.debug = False
 
 # If using SQLite:
-reahlsystem.connection_uri = 'sqlite:///%s/helloanywhere.db' % os.environ['HOME']
+reahlsystem.connection_uri = 'sqlite:///%s/helloanywhere.db' % os.path.expanduser('~')
 
 # If using MySql:
 # reahlsystem.connection_uri = 'mysql://myname:mydatabasepassword@myname.mysql.pythonanywhere-services.com/helloanywhere'

--- a/reahl-doc/reahl/doc/examples/tutorial/helloanywhere/prod/etc/web.config.py
+++ b/reahl-doc/reahl/doc/examples/tutorial/helloanywhere/prod/etc/web.config.py
@@ -11,5 +11,5 @@ web.default_http_port = 80
 web.encrypted_http_port = 443
 
 # Each application has one (and only one) directory where static files can be served from
-web.static_root = '%s/www' % os.environ['HOME']
+web.static_root = '%s/www' % os.path.expanduser('~')
 


### PR DESCRIPTION
 seems to be more platform friendly than using os.environ['HOME']