### PR TITLE
issue #160 fix methods that override WorkspaceCommand

### DIFF
--- a/reahl-dev/reahl/dev/devshell.py
+++ b/reahl-dev/reahl/dev/devshell.py
@@ -167,7 +167,7 @@ class DeleteSelection(WorkspaceCommand):
     """Deletes the saved selection set with the given name."""
     keyword = 'delete'
     usage_args = '<name>'
-    def execute(self, options, args):
+    def execute(self, args):
         self.workspace.delete_selection(args[0])
 
 

--- a/reahl-dev/reahl/dev/mailtest.py
+++ b/reahl-dev/reahl/dev/mailtest.py
@@ -74,7 +74,7 @@ class EchoSMTPServer(DebuggingServer):
 class ServeSMTP(WorkspaceCommand):
     """Runs an SMTP server on port 8025 for testing."""
     keyword = 'servesmtp'
-    def execute(self, options, args):
+    def execute(self, args):
         server = EchoSMTPServer()
         print("Running Echo SMTP Server on port 8025, type [ctrl-c] to exit.")
         try:


### PR DESCRIPTION
overridden methods should only expect arguments, not also options any more