### PR TITLE
Added reahl exportstatic 

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ python-reahl (4.1.0) unstable; urgency=low
 
  * Added Field.with_label #185.
  * Renamed Rename and expose in_production kwarg to strict_checking and expose it #174.
+ * Added reahl exportstatic #175.
 
  -- Iwan Vosloo <iwan@reahl.org>  Thu, 31 Jul 2018 15:15:00 +0200
 

--- a/reahl-commands/.reahlproject
+++ b/reahl-commands/.reahlproject
@@ -39,6 +39,7 @@
   <export entrypoint="reahl.component.commands" name="ListConfig" locator="reahl.commands.prodshell:ListConfig"/>
   <export entrypoint="reahl.component.commands" name="CheckConfig" locator="reahl.commands.prodshell:CheckConfig"/>
   <export entrypoint="reahl.component.commands" name="ListDependencies" locator="reahl.commands.prodshell:ListDependencies"/>
+  <export entrypoint="reahl.component.commands" name="ExportStaticFiles" locator="reahl.commands.prodshell:ExportStaticFiles"/>
 
 
   <distpackage type="wheel">

--- a/reahl-web/reahl/web/fw.py
+++ b/reahl-web/reahl/web/fw.py
@@ -2394,9 +2394,11 @@ class FileFromBlob(ViewableFile):
 
 
 class PackagedFile(FileOnDisk):
-    def __init__(self, egg, directory_name, relative_name):
+    def __init__(self, egg_name, directory_name, relative_name):
+        self.egg_name = egg_name
+        self.directory_name = directory_name
         egg_relative_name = '/'.join([directory_name, relative_name])
-        full_path = pkg_resources.resource_filename(Requirement.parse(egg), egg_relative_name)
+        full_path = pkg_resources.resource_filename(Requirement.parse(egg_name), egg_relative_name)
         super(PackagedFile, self).__init__(full_path, relative_name)
 
 


### PR DESCRIPTION
This adds a new production command `reahl exportstatic` which exports all files found in the config setting web.frontend_libraries, flattened into a given directory (fixes #175).