### PR TITLE
Run apt-ftparchive only when required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ addons:
   apt:
     packages:
        # Basic apt dependencies
-        - equivs 
         - openssh-client 
         - dpkg-dev
         - bzr

--- a/reahl-dev/reahl/dev/devshell.py
+++ b/reahl-dev/reahl/dev/devshell.py
@@ -409,13 +409,19 @@ class Setup(ForAllWorkspaceCommand):
 class Build(ForAllWorkspaceCommand):
     """Builds all distributable packages for each project in the current selection."""
     keyword = 'build'
+    def assemble(self):
+        super(Build, self).assemble()
+        self.parser.add_argument('-ns', '--nosign', action='store_true', dest='nosign', default=False,
+                                 help='don\'t sign build artifacts')
+
     def function(self, project, args):
-        project.build()
+        self.sign = not args.nosign
+        project.build(sign=self.sign)
         return 0
 
     def perform_post_command_duties(self):
-        print('Signing the apt repository')
-        self.workspace.update_apt_repository_index()
+        print('Updating the apt repository')
+        self.workspace.update_apt_repository_index(sign=self.sign)
 
 
 
@@ -461,9 +467,9 @@ class Upload(ForAllWorkspaceCommand):
         
     def function(self, project, args):
         if args.ignore_release_checks:
-            print('WARNING: Ignoring release checks at your request')
+            print('WARNING: Ignoring release checks at your request', file=sys.err)
         if args.ignore_upload_check:
-            print('WARNING: Overwriting possible previous uploads')
+            print('WARNING: Overwriting possible previous uploads', file=sys.err)
         project.upload(knocks=args.knocks, ignore_release_checks=args.ignore_release_checks, ignore_upload_check=args.ignore_upload_check)
         return 0
 

--- a/reahl-dev/reahl/dev/devshell.py
+++ b/reahl-dev/reahl/dev/devshell.py
@@ -294,10 +294,6 @@ class ForAllWorkspaceCommand(WorkspaceCommand):
             print('--- END ---\n')
 
         success = set(results.values()) == {0}
-        status_message = '' if success else '(despite failures)'
-        print('Performing post command duties %s' % status_message)
-        self.perform_post_command_duties()
-
         if success:
             return 0
         return 1
@@ -305,8 +301,6 @@ class ForAllWorkspaceCommand(WorkspaceCommand):
     def format_individual_message(self, project, args, template):
         return template % project.relative_directory
     
-    def perform_post_command_duties(self):
-        pass
 
 
 class Debianise(ForAllWorkspaceCommand):
@@ -418,11 +412,6 @@ class Build(ForAllWorkspaceCommand):
         self.sign = not args.nosign
         project.build(sign=self.sign)
         return 0
-
-    def perform_post_command_duties(self):
-        print('Updating the apt repository')
-        self.workspace.update_apt_repository_index(sign=self.sign)
-
 
 
 class ListMissingDependencies(ForAllWorkspaceCommand):

--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -161,7 +161,7 @@ def find_missing_dependencies(workspace):
 
 def print_final_message(success=True):
     debs_needed_to_compile_python = ['python-virtualenv', 'python-dev', 'gcc', 'cython', 'libxml2-dev', 'libxslt-dev', 'libsqlite3-0', 'sqlite3', 'postgresql-server-dev-all', 'zlib1g-dev', 'libjpeg62-dev', 'libfreetype6-dev', 'liblcms1-dev', 'mysql-client', 'libmysqlclient-dev']
-    general_debs_needed = ['equivs', 'openssh-client', 'dpkg-dev', 'chromium-browser', 'chromium-chromedriver']
+    general_debs_needed = ['openssh-client', 'dpkg-dev', 'chromium-browser', 'chromium-chromedriver']
 
     print('')
     print('')

--- a/scripts/installDebs.sh
+++ b/scripts/installDebs.sh
@@ -2,7 +2,7 @@
 
 # Installs needed to develop on reahl itself
 
-PYTHON_DEPS="python3 python3-virtualenv virtualenvwrapper python3-dev gcc cython libxml2-dev libxslt-dev libsqlite3-0 sqlite3 postgresql-server-dev-all zlib1g-dev libfreetype6-dev equivs build-essential openssh-client dpkg-dev postgresql libyaml-dev mysql-client mysql-server libmysqlclient-dev"
+PYTHON_DEPS="python3 python3-virtualenv virtualenvwrapper python3-dev gcc cython libxml2-dev libxslt-dev libsqlite3-0 sqlite3 postgresql-server-dev-all zlib1g-dev libfreetype6-dev build-essential openssh-client dpkg-dev postgresql libyaml-dev mysql-client mysql-server libmysqlclient-dev"
 UTILS="screen unzip git"
 
 # For X11 forwarding to work and other misc stuff we need


### PR DESCRIPTION
We used to run apt-ftparchive always at the end of a build, regardless of whether you have built debs or not. This change updates the archive after every DebianArchive package has been built, and only then. Hence, if there are no debs defined, it will never get run.

Closes #143 