### PR TITLE
fixes #183 - Executable not installed

### DIFF
--- a/reahl-component/reahl/component/exceptions.py
+++ b/reahl-component/reahl/component/exceptions.py
@@ -34,6 +34,7 @@ else:
 
 _ = Catalogue('reahl-component')
 
+
 class DomainException(Exception):
     """Any exception indicating an application-specific error condition that 
        should be communicated to a user.


### PR DESCRIPTION
When installing postgresql on certain OS's, the executables are not necessarily added to the search path. Rather just state the fact than producing a stack trace.