### PR TITLE
Fixes #245

### DIFF
--- a/reahl-component/reahl/component/dbutils.py
+++ b/reahl-component/reahl/component/dbutils.py
@@ -235,10 +235,10 @@ class DatabaseControl(object):
             raise ProgrammerError('Please specify a database name in reahlsystem.connection_uri')
 
     def unquote(self, value):
-        unquote = urllib_parse.unquote(value) if value else None
-        if unquote and six.PY2:
-            unquote = unquote.decode('utf-8')
-        return unquote
+        unquote_value = urllib_parse.unquote(value) if value else None
+        if unquote_value and six.PY2:
+            unquote_value = unquote_value.decode('utf-8')
+        return unquote_value
 
     def get_dbapi_connection_creator(self):
         return None

--- a/reahl-component/reahl/component/dbutils.py
+++ b/reahl-component/reahl/component/dbutils.py
@@ -226,7 +226,7 @@ class DatabaseControl(object):
         self.connection_uri = url
         uri_parts = urllib_parse.urlparse(url)
         self.user_name = uri_parts.username
-        self.password = uri_parts.password
+        self.password = urllib_parse.unquote(uri_parts.password) if uri_parts.password else None
         self.host = uri_parts.hostname
         self.port = uri_parts.port
         self.database_name = uri_parts.path[1:] if uri_parts.path.startswith('/') else uri_parts.path
@@ -253,7 +253,6 @@ class DatabaseControl(object):
     
 class NullDatabaseControl(DatabaseControl):
     """A stubbed-out :class:`DatabaseControl` for systems that do not have any database at all."""
-    uri_regex_string = r''
 
     def donothing(self, *args, **kwargs):
         pass

--- a/reahl-component/reahl/component/dbutils.py
+++ b/reahl-component/reahl/component/dbutils.py
@@ -23,6 +23,7 @@
 
 from __future__ import print_function, unicode_literals, absolute_import, division
 import re
+import six
 from contextlib import contextmanager
 from six.moves.urllib import parse as urllib_parse
 
@@ -234,7 +235,10 @@ class DatabaseControl(object):
             raise ProgrammerError('Please specify a database name in reahlsystem.connection_uri')
 
     def unquote(self, value):
-        return urllib_parse.unquote(value).decode('utf-8') if value else None
+        unquote = urllib_parse.unquote(value) if value else None
+        if unquote and six.PY2:
+            unquote = unquote.decode('utf-8')
+        return unquote
 
     def get_dbapi_connection_creator(self):
         return None

--- a/reahl-component/reahl/component/dbutils.py
+++ b/reahl-component/reahl/component/dbutils.py
@@ -234,7 +234,7 @@ class DatabaseControl(object):
             raise ProgrammerError('Please specify a database name in reahlsystem.connection_uri')
 
     def unquote(self, value):
-        return urllib_parse.unquote(value) if value else None
+        return urllib_parse.unquote(value).decode('utf-8') if value else None
 
     def get_dbapi_connection_creator(self):
         return None

--- a/reahl-component/reahl/component/dbutils.py
+++ b/reahl-component/reahl/component/dbutils.py
@@ -225,13 +225,16 @@ class DatabaseControl(object):
         self.config = config
         self.connection_uri = url
         uri_parts = urllib_parse.urlparse(url)
-        self.user_name = uri_parts.username
-        self.password = urllib_parse.unquote(uri_parts.password) if uri_parts.password else None
-        self.host = uri_parts.hostname
+        self.user_name = self.unquote(uri_parts.username)
+        self.password = self.unquote(uri_parts.password)
+        self.host = self.unquote(uri_parts.hostname)
         self.port = uri_parts.port
-        self.database_name = uri_parts.path[1:] if uri_parts.path.startswith('/') else uri_parts.path
+        self.database_name = self.unquote(uri_parts.path[1:] if uri_parts.path.startswith('/') else uri_parts.path)
         if not self.database_name:
             raise ProgrammerError('Please specify a database name in reahlsystem.connection_uri')
+
+    def unquote(self, value):
+        return urllib_parse.unquote(value) if value else None
 
     def get_dbapi_connection_creator(self):
         return None

--- a/reahl-component/reahl/component_dev/test_dbutils.py
+++ b/reahl-component/reahl/component_dev/test_dbutils.py
@@ -126,7 +126,7 @@ def test_database_control_url_safe_parts(dbcontrol_fixture):
         = ['usêrname', 'p#=sword', 'hõst', 'd~t∀b^s∊']
 
     def quote(values):
-        return [urllib_parse.quote(i) for i in values]
+        return [urllib_parse.quote(i.encode('utf-8')) for i in values]
 
     fixture.config.reahlsystem.connection_uri = 'myprefix://%s:%s@%s:456/%s' % tuple(quote(expected_parts))
 

--- a/reahl-component/reahl/component_dev/test_dbutils.py
+++ b/reahl-component/reahl/component_dev/test_dbutils.py
@@ -119,7 +119,7 @@ def test_minimum_required_database_control_settings(dbcontrol_fixture):
 
 @with_fixtures(DBControlFixture)
 def test_database_control_url_safe_parts(dbcontrol_fixture):
-    """URL parts may need to be unquoted, as they might have been quoted to be URL safe (ASCII).
+    """URL parts are unquoted, as they may contain URL quoted characters.
     """
     fixture = dbcontrol_fixture
 

--- a/reahl-component/reahl/component_dev/test_dbutils.py
+++ b/reahl-component/reahl/component_dev/test_dbutils.py
@@ -1,4 +1,5 @@
 # Copyright 2016, 2017, 2018 Reahl Software Services (Pty) Ltd. All rights reserved.
+#-*- encoding: utf-8 -*-
 #
 #    This file is part of Reahl.
 #

--- a/reahl-dev/reahl_dev.egg-info/SOURCES.txt
+++ b/reahl-dev/reahl_dev.egg-info/SOURCES.txt
@@ -4,6 +4,7 @@
 COPYING
 LICENSE
 MANIFEST.in
+setup.py
 tox.ini
 reahl/__init__.py
 reahl/dev/__init__.py

--- a/reahl-dev/reahl_dev.egg-info/SOURCES.txt
+++ b/reahl-dev/reahl_dev.egg-info/SOURCES.txt
@@ -4,7 +4,6 @@
 COPYING
 LICENSE
 MANIFEST.in
-setup.py
 tox.ini
 reahl/__init__.py
 reahl/dev/__init__.py


### PR DESCRIPTION
Passwords containing special characters (i.e. reserved, punctuation etc.) should be decoded when parsed from the URI