### PR TITLE
Changed how namespaces work

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -21,7 +21,7 @@ python-reahl (5.0.0a1) unstable; urgency=low
  * Changed Table and Column to allow for table footer content in Columns.
  * Changed the names of Inputs to include their form names so they can be unique in JS state (#154).
  * Added unique IDs to all HTML input controls (#154).
- * Added Field.in_namespace() (and removed name kwarg to PrimitiveInputs) for distinguishing same-named inputs.
+ * Added Field.with_discriminator (and removed name kwarg to PrimitiveInputs) for distinguishing same-named inputs.
  * Removed the in_production kwarg for StoredConfiguration (#174). Rather use strict_checking.
  * Moved reahl.web.bootstrap.ui.HTML5Page to reahl.web.bootstrap.page to resolve dependency issues.
  * Added a way to render customised error pages.

--- a/debian/changelog
+++ b/debian/changelog
@@ -21,7 +21,7 @@ python-reahl (5.0.0a1) unstable; urgency=low
  * Changed Table and Column to allow for table footer content in Columns.
  * Changed the names of Inputs to include their form names so they can be unique in JS state (#154).
  * Added unique IDs to all HTML input controls (#154).
- * Added Field.with_namespace() (and removed name kwarg to PrimitiveInputs) for distinguishing same-named inputs.
+ * Added Field.in_namespace() (and removed name kwarg to PrimitiveInputs) for distinguishing same-named inputs.
  * Removed the in_production kwarg for StoredConfiguration (#174). Rather use strict_checking.
  * Moved reahl.web.bootstrap.ui.HTML5Page to reahl.web.bootstrap.page to resolve dependency issues.
  * Added a way to render customised error pages.

--- a/reahl-component/reahl/component/modelinterface.py
+++ b/reahl-component/reahl/component/modelinterface.py
@@ -855,17 +855,28 @@ class Field:
         new_version.label = label
         return new_version
 
-    def in_namespace(self, namespace):
-        """Returns a new Field which shares this one's underlying data, but its name is mangled to 
+    def with_discriminator(self, discriminator):
+        """Returns a new Field which is exactly like this one, except that its name is mangled to 
            include the given text as to prevent name clashes.
 
         .. versionadded:: 5.0
         """
         new_field = self.copy()
+        new_field.push_namespace(discriminator)
+        return new_field
+
+    def in_namespace(self, namespace):
+        new_field = self.copy()
         new_field.push_namespace(namespace)
         new_field.data = self.data
         return new_field
 
+    def out_of_namespace(self):
+        new_field = self.copy()
+        new_field.pop_namespace()
+        new_field.data = self.data
+        return new_field
+        
     def clear_user_input(self):
         self.input_status = 'defaulted'
         self.validation_error = None
@@ -924,7 +935,7 @@ class Field:
     def name(self):
         if not self._name:
             raise AssertionError('field %s with label "%s" is not yet bound' % (self, self.label))
-        return '-'.join(self.namespace + [self._name])
+        return '-'.join(reversed([self._name] + self.namespace))
 
     @property
     def variable_name(self):

--- a/reahl-component/reahl/component_dev/test_field.py
+++ b/reahl-component/reahl/component_dev/test_field.py
@@ -239,6 +239,90 @@ def test_getting_modified_copy(fixture):
     assert differently_labelled_field.label == 'new label'
     
 
+def test_global_state():
+    """A Field can store its data in a global dict so that it can be recreated later with the same underlying data."""
+    ExecutionContext().install()
+    state_dict = {}
+    a = Field()
+    a.bind('x', a)
+
+    a.input_status = EmptyStub()
+    a.validation_error = EmptyStub()
+    a.user_input = EmptyStub()
+    a.parsed_input = EmptyStub()
+
+    a.activate_global_field_data_store(state_dict)
+
+    a.initial_value = EmptyStub()
+
+    b = Field()
+    b.bind('x', b)
+
+    assert a.initial_value is not b.initial_value
+    assert a.input_status  is not b.input_status
+    assert a.validation_error is not b.validation_error
+    assert a.user_input  is not b.user_input
+    assert a.parsed_input is not b.parsed_input
+
+    b.activate_global_field_data_store(state_dict)
+
+    assert a.initial_value is b.initial_value
+    assert a.input_status  is b.input_status
+    assert a.validation_error is b.validation_error
+    assert a.user_input  is b.user_input
+    assert a.parsed_input is b.parsed_input
+
+
+def test_when_initial_value_is_read():
+    """The initial_value of a Field is set upon first activate_global_field_data_store"""
+    ExecutionContext().install()
+    state_dict = {}
+    a = Field()
+    a.bind('x', a)
+    a.x = 'initial value for a'
+
+    assert not a.initial_value
+
+    a.activate_global_field_data_store(state_dict)
+
+    assert a.initial_value == a.x
+
+    a.x = 'changed value'
+    a.activate_global_field_data_store(state_dict)
+
+    assert a.initial_value != a.x
+
+
+def test_namespaces():
+    ExecutionContext().install()
+    state_dict = {}
+    a = Field()
+    a.bind('x', a)
+
+    # Case: namespaces change the name of the Field
+    b = a.in_namespace('deeper')
+
+    assert a.name == 'x'
+    assert b.name == 'deeper-x'
+
+    # Case: namespaces can be nested 
+    c = b.in_namespace('even')
+    assert c.name == 'even-deeper-x'
+
+    # Case: a Field *in* different namespace, but made from another share the same data
+    a.initial_value = EmptyStub()
+    a.input_status = EmptyStub()
+    a.validation_error = EmptyStub()
+    a.user_input = EmptyStub()
+    a.parsed_input = EmptyStub()
+
+    assert a.initial_value is b.initial_value is c.initial_value
+    assert a.input_status  is b.input_status is c.input_status
+    assert a.validation_error is b.validation_error is c.validation_error
+    assert a.user_input  is b.user_input is c.user_input
+    assert a.parsed_input is b.parsed_input is c.parsed_input
+
+
 @with_fixtures(FieldFixture)
 def test_helpers_for_fields(fixture):
     """The @exposed decorator makes it simpler to bind Fields to an object."""

--- a/reahl-doc/doc/whatchanged.rst
+++ b/reahl-doc/doc/whatchanged.rst
@@ -23,7 +23,7 @@ What changed in version 5.0
 .. |exposed| replace:: :class:`~reahl.component.modelinterface.exposed`
 .. |FieldIndex| replace:: :class:`~reahl.component.modelinterface.FieldIndex`
 .. |Field| replace:: :class:`~reahl.component.modelinterface.Field`
-.. |with_namespace| replace:: :meth:`~reahl.component.modelinterface.Field.with_namespace`
+.. |in_namespace| replace:: :meth:`~reahl.component.modelinterface.Field.in_namespace`
 .. |Layout| replace:: :class:`~reahl.web.fw.Layout`
 .. |HTML5Page| replace:: :class:`~reahl.web.bootstrap.page.HTML5Page`
 .. |ReahlWSGIApplication| replace:: :class:`~reahl.web.fw.ReahlWSGIApplication`
@@ -75,11 +75,11 @@ Unique input names and IDs
    The name of an |Input| is derived from the name of its |Field|. Previously |Input| names used to be adapted
    automatically as to prevent name clashes between different |Input|\s on a form. This is no 
    longer the case: an Input that has a name clash with another is now explicitly disambiguated by passing 
-   it a |Field| that is placed in a distinct namespace (see |with_namespace|).
+   it a |Field| that is placed in a distinct namespace (see |in_namespace|).
 
    Every Input now also is generated with an ID that is unique on the page.
 
-   All distinct |Field|\s on a page also have to have distinct names. |with_namespace| is used to disambiguate
+   All distinct |Field|\s on a page also have to have distinct names. |in_namespace| is used to disambiguate
    different |Field|\s with the name as well.
 
 Changes to nested_transaction

--- a/reahl-doc/doc/whatchanged.rst
+++ b/reahl-doc/doc/whatchanged.rst
@@ -23,7 +23,7 @@ What changed in version 5.0
 .. |exposed| replace:: :class:`~reahl.component.modelinterface.exposed`
 .. |FieldIndex| replace:: :class:`~reahl.component.modelinterface.FieldIndex`
 .. |Field| replace:: :class:`~reahl.component.modelinterface.Field`
-.. |in_namespace| replace:: :meth:`~reahl.component.modelinterface.Field.in_namespace`
+.. |with_discriminator| replace:: :meth:`~reahl.component.modelinterface.Field.with_discriminator`
 .. |Layout| replace:: :class:`~reahl.web.fw.Layout`
 .. |HTML5Page| replace:: :class:`~reahl.web.bootstrap.page.HTML5Page`
 .. |ReahlWSGIApplication| replace:: :class:`~reahl.web.fw.ReahlWSGIApplication`
@@ -73,14 +73,12 @@ ButtonInput
 
 Unique input names and IDs
    The name of an |Input| is derived from the name of its |Field|. Previously |Input| names used to be adapted
-   automatically as to prevent name clashes between different |Input|\s on a form. This is no 
+   automatically so as to prevent name clashes between different |Input|\s on a |Form|. This is no 
    longer the case: an Input that has a name clash with another is now explicitly disambiguated by passing 
-   it a |Field| that is placed in a distinct namespace (see |in_namespace|).
+   it a |Field| with a modified name (see |with_descriminator|).
 
-   Every Input now also is generated with an ID that is unique on the page.
-
-   All distinct |Field|\s on a page also have to have distinct names. |in_namespace| is used to disambiguate
-   different |Field|\s with the name as well.
+   Every Input is also now generated with a name and an ID that include the |Form|\'s ID and hence are both 
+   unique on the entire page.
 
 Changes to nested_transaction
    |nested_transaction| used to yield the transaction object. It now yields a |TransactionVeto| object which

--- a/reahl-doc/reahl/doc/examples/howtos/responsivedisclosure/responsivedisclosure.py
+++ b/reahl-doc/reahl/doc/examples/howtos/responsivedisclosure/responsivedisclosure.py
@@ -131,7 +131,7 @@ class AllocationDetailSection(Div):
 
     def make_allocation_input(self, allocation, field):
         div = Div(self.view).use_layout(FormLayout())
-        div.layout.add_input(TextInput(self.form, field.with_namespace(allocation.fund_code), refresh_widget=self), hide_label=True)
+        div.layout.add_input(TextInput(self.form, field.in_namespace(allocation.fund_code), refresh_widget=self), hide_label=True)
         return div
 
     def make_total_widget(self, total_value):

--- a/reahl-doc/reahl/doc/examples/howtos/responsivedisclosure/responsivedisclosure.py
+++ b/reahl-doc/reahl/doc/examples/howtos/responsivedisclosure/responsivedisclosure.py
@@ -131,7 +131,7 @@ class AllocationDetailSection(Div):
 
     def make_allocation_input(self, allocation, field):
         div = Div(self.view).use_layout(FormLayout())
-        div.layout.add_input(TextInput(self.form, field.in_namespace(allocation.fund_code), refresh_widget=self), hide_label=True)
+        div.layout.add_input(TextInput(self.form, field.with_discriminator(allocation.fund_code), refresh_widget=self), hide_label=True)
         return div
 
     def make_total_widget(self, total_value):

--- a/reahl-doc/reahl/doc/examples/tutorial/dynamiccontent/dynamiccontent.py
+++ b/reahl-doc/reahl/doc/examples/tutorial/dynamiccontent/dynamiccontent.py
@@ -70,7 +70,7 @@ class AllocationDetailForm(Form):
 
     def make_allocation_input(self, allocation, field):
         div = Div(self.view).use_layout(FormLayout())
-        div.layout.add_input(TextInput(self, field.in_namespace(allocation.fund_code), refresh_widget=self), hide_label=True)
+        div.layout.add_input(TextInput(self, field.with_discriminator(allocation.fund_code), refresh_widget=self), hide_label=True)
         return div
 
     def make_total_widget(self, total_value):

--- a/reahl-doc/reahl/doc/examples/tutorial/dynamiccontent/dynamiccontent.py
+++ b/reahl-doc/reahl/doc/examples/tutorial/dynamiccontent/dynamiccontent.py
@@ -70,7 +70,7 @@ class AllocationDetailForm(Form):
 
     def make_allocation_input(self, allocation, field):
         div = Div(self.view).use_layout(FormLayout())
-        div.layout.add_input(TextInput(self, field.with_namespace(allocation.fund_code), refresh_widget=self), hide_label=True)
+        div.layout.add_input(TextInput(self, field.in_namespace(allocation.fund_code), refresh_widget=self), hide_label=True)
         return div
 
     def make_total_widget(self, total_value):

--- a/reahl-doc/reahl/doc/examples/tutorial/tablebootstrap/tablebootstrap.py
+++ b/reahl-doc/reahl/doc/examples/tutorial/tablebootstrap/tablebootstrap.py
@@ -92,7 +92,7 @@ class AddressBookPanel(Div):
             return A.from_bookmark(view, address_book_ui.get_edit_bookmark(row.address, description='Edit'))
 
         def make_checkbox_widget(view, row):
-            return PrimitiveCheckboxInput(form, row.fields.selected_by_user.with_namespace(str(row.address.id)))
+            return PrimitiveCheckboxInput(form, row.fields.selected_by_user.in_namespace(str(row.address.id)))
 
         def make_delete_selected_button(view):
             return Button(form, self.events.delete_selected)

--- a/reahl-doc/reahl/doc/examples/tutorial/tablebootstrap/tablebootstrap.py
+++ b/reahl-doc/reahl/doc/examples/tutorial/tablebootstrap/tablebootstrap.py
@@ -92,7 +92,7 @@ class AddressBookPanel(Div):
             return A.from_bookmark(view, address_book_ui.get_edit_bookmark(row.address, description='Edit'))
 
         def make_checkbox_widget(view, row):
-            return PrimitiveCheckboxInput(form, row.fields.selected_by_user.in_namespace(str(row.address.id)))
+            return PrimitiveCheckboxInput(form, row.fields.selected_by_user.with_discriminator(str(row.address.id)))
 
         def make_delete_selected_button(view):
             return Button(form, self.events.delete_selected)

--- a/reahl-domainui/reahl/domainui_dev/bootstrap/test_workflow.py
+++ b/reahl-domainui/reahl/domainui_dev/bootstrap/test_workflow.py
@@ -29,7 +29,7 @@ from reahl.domainui.bootstrap.accounts import AccountUI
 from reahl.domainuiegg import DomainUiConfig
 from reahl.domainui_dev.fixtures import BookmarkStub
 
-from reahl.webdev.tools import Browser
+from reahl.webdev.tools import Browser, XPath
 
 from reahl.web.fw import UserInterface, Url
 from reahl.web.layout import PageLayout
@@ -107,9 +107,9 @@ def test_detour_to_login(web_fixture, party_account_fixture, workflow_web_fixtur
 
     browser.open('/inbox/')
     assert browser.current_url.path == '/accounts/login'
-    browser.type('//input[@name="email"]', party_account_fixture.system_account.email)
-    browser.type('//input[@name="password"]', party_account_fixture.system_account.password)
-    browser.click('//input[@value="Log in"]')
+    browser.type(XPath.input_labelled('Email'), party_account_fixture.system_account.email)
+    browser.type(XPath.input_labelled('Password'), party_account_fixture.system_account.password)
+    browser.click(XPath.button_labelled('Log in'))
     assert browser.current_url.path == '/inbox/'
 
 
@@ -120,10 +120,10 @@ def test_take_and_release_task(web_fixture, task_queue_fixture, workflow_web_fix
     browser = Browser(fixture.wsgi_app)
     task = task_queue_fixture.task
 
-    take_task_button = '//input[@value="Take"]'
-    defer_task_button = '//input[@value="Defer"]'
-    release_task_button = '//input[@value="Release"]'
-    go_to_task_button = '//input[@value="Go to"]'
+    take_task_button = XPath.button_labelled('Take')
+    defer_task_button = XPath.button_labelled('Defer')
+    release_task_button = XPath.button_labelled('Release')
+    go_to_task_button = XPath.button_labelled('Go to')
 
     web_fixture.log_in(browser=browser)
     browser.open('/inbox/')

--- a/reahl-web/reahl/web/bootstrap/files.py
+++ b/reahl-web/reahl/web/bootstrap/files.py
@@ -253,7 +253,7 @@ class FileUploadInput(reahl.web.ui.Input):
 
     def get_concurrency_hash_strings(self):
         if not self.ignore_concurrency_change:
-            yield self.original_value
+            yield self.original_database_value
             
     @property
     def name(self):

--- a/reahl-web/reahl/web/bootstrap/reahl.bootstrapfileuploadpanel.js
+++ b/reahl-web/reahl/web/bootstrap/reahl.bootstrapfileuploadpanel.js
@@ -52,16 +52,16 @@ $.widget('reahl.bootstrapfileuploadpanel', {
         return this.options.errorMessage;
     },
     getUploadInput: function() {
-        return $(this.element).find('input[name^="event.upload_file"]');
+        return $(this.element).find('input[name^="event.'+this.getFormId()+'-upload_file"]');
     },
     getRemoveFileButtonName: function() {
-        return 'event.remove_file';
+        return 'event.'+this.getFormId()+'-remove_file';
     },
     getFileInput: function() {
         return $(this.element).find('input[type="file"]');
     },
     getValidationError: function() {
-        return $(this.element).find('span[data-generated-for="'+this.fileInputId+'"][class~="invalid-feedback"]');
+        return $(this.element).find('span[for="'+this.fileInputName+'"][class~="invalid-feedback"]');
     },
     getNumberOfUploadedFiles: function() {
         return $(this.element).find('li').length;
@@ -72,8 +72,7 @@ $.widget('reahl.bootstrapfileuploadpanel', {
         this.queuedUploads = [];
         this.uploadInputName = this.getUploadInput().attr('name');
         this.fileInputName = this.getFileInput().attr('name');
-        this.fileInputId = this.getFileInput().attr('id');
-        this.duplicateValidationError = $('<span data-generated-for="'+this.fileInputId+'" class="invalid-feedback">'+this.options.duplicateValidationErrorMessage+'</span>');
+        this.duplicateValidationError = $('<span data-generated-for="'+this.fileInputName+'" class="invalid-feedback">'+this.options.duplicateValidationErrorMessage+'</span>');
         this.uploadCounter = 0;
 
         $(this.element).on('click', 'input[name="'+this_.uploadInputName+'"]', function(e){

--- a/reahl-web/reahl/web/egg.py
+++ b/reahl-web/reahl/web/egg.py
@@ -72,6 +72,8 @@ class WebConfig(Configuration):
                                       description='The time in seconds after which a user session will be considered idle - "forever" setting')
     idle_secure_lifetime = ConfigSetting(default=60*60,
                                          description='The time in seconds after which a secure session will be considered expired')
+    debug_concurrency_hash = ConfigSetting(default=False,
+                                   description='If True, replaces the concurrency hash with a long string indicating the values used in calculating the hash')
                                        
     @property
     def secure_key_name(self):

--- a/reahl-web/reahl/web/fw.py
+++ b/reahl-web/reahl/web/fw.py
@@ -1247,19 +1247,15 @@ class Widget:
     def check_form_related_programmer_errors(self):
         inputs = []
         forms = []
-        unique_fields = set()
 
         for widget in itertools.chain([self], self.contained_widgets()):
             if widget.is_Form:
                 forms.append(widget)
             elif widget.is_Input:
                 inputs.append(widget)
-                if not getattr(widget, 'is_contained', False) and not isinstance(widget.bound_field, Event):
-                    unique_fields.add(widget.bound_field)
 
         self.check_forms_unique(forms)
         self.check_all_inputs_forms_exist(forms, inputs)
-        self.check_fields_uniquely_named(unique_fields)
 
     def check_all_inputs_forms_exist(self, forms_found_on_page, inputs_on_page):
         for i in inputs_on_page:
@@ -1277,16 +1273,6 @@ class Widget:
                 existing_form = checked_forms[form.css_id]
                 message = 'More than one form was added using the same unique_name: %s and %s' % (form, existing_form)
                 raise ProgrammerError(message)
-
-    def check_fields_uniquely_named(self, fields):
-        names = {}
-        for i in fields:
-            names.setdefault(i.name, []).append(i)
-        
-        problem_names = {name:fields_for_name for name, fields_for_name in names.items()
-                         if len(fields_for_name) > 1}
-        if problem_names:
-            raise ProgrammerError('There is more than one Field with the same name on this page: %s' % problem_names)
 
     def plug_in(self, view):
         self.check_slots(view)

--- a/reahl-web/reahl/web/fw.py
+++ b/reahl-web/reahl/web/fw.py
@@ -1035,6 +1035,9 @@ class Widget:
         if not self.visible:
             return ''
 
+        if ExecutionContext.get_context().config.web.debug_concurrency_hash:
+            return self.get_concurrency_hash_digest_debug()
+
         concurrency_hash = hashlib.md5()
         is_empty = True
         for value in self.get_concurrency_hash_strings():
@@ -1046,10 +1049,7 @@ class Widget:
             concurrency_hash.update(str(self.disabled).encode('utf-8'))
             return concurrency_hash.hexdigest()
 
-    def xxget_concurrency_hash_digest(self):
-        if not self.visible:
-            return ''
-
+    def get_concurrency_hash_digest_debug(self):
         concurrency_hash = self.get_concurrency_hash_strings()
 
         if not concurrency_hash:

--- a/reahl-web/reahl/web/static/reahl.validate.js
+++ b/reahl-web/reahl/web/static/reahl.validate.js
@@ -27,9 +27,9 @@ jQuery.validator.addMethod("equalTo2", function(value, element, param) {
     // Bind to the blur event of the target in order to revalidate whenever the target field is updated
     var target = null;
     if (element.form && element.form.elements) {
-        target = $($(element.form.elements).filter("input[name='"+param+"']")[0]);
+        target = $($(element.form.elements).filter("input[name='"+$(element.form).attr('id')+"-"+param+"']")[0]);
     } else {
-        target = $(element).closest("form").find("input[name='"+param+"']");
+        target = $(element).closest("form").find("input[name='"+$(element.form).attr('id')+"-"+param+"']");
     }
     if ( this.settings.onfocusout && target.not( ".validate-equalTo-blur" ).length ) {
         target.addClass( "validate-equalTo-blur" ).on( "blur.validate-equalTo", function() {

--- a/reahl-web/reahl/web/ui.py
+++ b/reahl-web/reahl/web/ui.py
@@ -1078,8 +1078,7 @@ class Form(HTMLElement):
                 attributes.set_to('value', digest)
 
         self.hash_inputs = self.add_child(Div(self.view, css_id='%s_hashes' % unique_name))
-
-        self.database_digest_input = self.hash_inputs.add_child(HiddenInput(self, self.fields._reahl_database_concurrency_digest.in_namespace(unique_name), ignore_concurrent_change=True))
+        self.database_digest_input = self.hash_inputs.add_child(HiddenInput(self, self.fields._reahl_database_concurrency_digest, ignore_concurrent_change=True))
         # the digest input will have a value when:
         #  (1) you're busy with an ajax call, after being internally redirected (because AjaxMethod.fire_ajax_event will have inputted the browser value); or
         #  (2) you're busy submitting and you saved its value because of an validation exception (and prepare_input read the value from saved inputs due to the exception)
@@ -1603,7 +1602,7 @@ class PrimitiveInput(Input):
     is_contained = False
 
     def __init__(self, form, bound_field, registers_with_form=True, refresh_widget=None, ignore_concurrent_change=False):
-        super().__init__(form, bound_field)
+        super().__init__(form, bound_field.in_namespace(form.channel_name) if registers_with_form else bound_field)
 
         self.ignore_concurrent_change = ignore_concurrent_change
 
@@ -1628,7 +1627,7 @@ class PrimitiveInput(Input):
             self.set_attribute('data-refresh-widget-id', self.refresh_widget.css_id)
 
     def make_html_control_css_id(self):
-        return str(CssId.from_dirty_string('id-%s-%s' % (self.channel_name, self.name)))
+        return str(CssId.from_dirty_string('id-%s' % (self.name)))
 
     def add_input_data_attributes(self):
         if isinstance(self.bound_field, BooleanField):
@@ -1849,7 +1848,7 @@ class ContainedInput(PrimitiveInput):
         super().__init__(containing_input.form, choice.field, registers_with_form=False, refresh_widget=refresh_widget)
 
     def make_html_control_css_id(self):
-        return str(CssId.from_dirty_string('id-%s-%s-%s' % (self.channel_name, self.containing_input.name, self.value)))
+        return str(CssId.from_dirty_string('id-%s-%s' % (self.containing_input.name, self.value)))
 
     def get_input_status(self):
         return 'defaulted'
@@ -2317,7 +2316,7 @@ class ButtonInput(PrimitiveInput):
 
     def get_ocurred_event(self):
         if self.bound_field.occurred:
-            return self.bound_field
+            return self.bound_field.out_of_namespace()
         return None
 
     def create_html_widget(self):

--- a/reahl-web/reahl/web/ui.py
+++ b/reahl-web/reahl/web/ui.py
@@ -1030,9 +1030,8 @@ class ConcurrentChange(ValidationConstraint):
     def validate_input(self, unparsed_input):
         if unparsed_input != self.form.get_concurrency_hash_digest():
             self.failed = True
-            #xxxxx
-#            from string import Template
-#            self.error_message = Template('Failing concurrency check: [%s] != [%s]' % (unparsed_input, self.form.get_concurrency_hash_digest()))
+            if ExecutionContext.get_context().config.web.debug_concurrency_hash:
+                self.error_message = Template('Failing concurrency check: submitted[%s] != calculated[%s]' % (unparsed_input, self.form.get_concurrency_hash_digest()))
             raise self
 
 
@@ -1646,11 +1645,10 @@ class PrimitiveInput(Input):
 
     def get_concurrency_hash_strings(self):
         if not self.ignore_concurrent_change:
-            yield self.original_database_value
-
-    def xxxget_concurrency_hash_strings(self):
-        if not self.ignore_concurrent_change:
-            yield '%s[%s]' % (self.name, self.original_database_value)
+            if ExecutionContext.get_context().config.web.debug_concurrency_hash:
+                yield '%s[%s]' % (self.name, self.original_database_value)
+            else:
+                yield self.original_database_value
 
     @property
     def html_control(self):
@@ -1727,7 +1725,7 @@ class PrimitiveInput(Input):
         return self.form.persisted_userinput_class
 
     def prepare_input(self):
-        field_data_store = ExecutionContext.get_context().initial_field_values = getattr(ExecutionContext.get_context(), 'global_field_values', {})
+        field_data_store = ExecutionContext.get_context().global_field_values = getattr(ExecutionContext.get_context(), 'global_field_values', {})
         self.bound_field.activate_global_field_data_store(field_data_store)
         
         construction_state = self.view.get_construction_state()

--- a/reahl-web/reahl/web/ui.py
+++ b/reahl-web/reahl/web/ui.py
@@ -1551,15 +1551,8 @@ class Input(HTMLWidget):
         return self.bound_field.as_user_input_value(self.get_input_status())
 
     @property
-    def original_value(self):
-        return self.bound_field.as_user_input_value('defaulted')
-
-    @property
     def original_database_value(self):
-        if self.bound_field.has_changed_model:
-            return self.bound_field.get_initial_value_as_user_input()
-        else:
-            return self.original_value
+        return self.bound_field.get_initial_value_as_user_input()
 
     def get_input_status(self):
         return self.bound_field.input_status

--- a/reahl-web/reahl/web/ui.py
+++ b/reahl-web/reahl/web/ui.py
@@ -1080,7 +1080,7 @@ class Form(HTMLElement):
 
         self.hash_inputs = self.add_child(Div(self.view, css_id='%s_hashes' % unique_name))
 
-        self.database_digest_input = self.hash_inputs.add_child(HiddenInput(self, self.fields._reahl_database_concurrency_digest.with_namespace(unique_name), ignore_concurrent_change=True))
+        self.database_digest_input = self.hash_inputs.add_child(HiddenInput(self, self.fields._reahl_database_concurrency_digest.in_namespace(unique_name), ignore_concurrent_change=True))
         # the digest input will have a value when:
         #  (1) you're busy with an ajax call, after being internally redirected (because AjaxMethod.fire_ajax_event will have inputted the browser value); or
         #  (2) you're busy submitting and you saved its value because of an validation exception (and prepare_input read the value from saved inputs due to the exception)
@@ -1727,8 +1727,8 @@ class PrimitiveInput(Input):
         return self.form.persisted_userinput_class
 
     def prepare_input(self):
-        value_store = ExecutionContext.get_context().initial_field_values = getattr(ExecutionContext.get_context(), 'initial_field_values', {})
-        self.bound_field.activate_initial_value_store(value_store)
+        field_data_store = ExecutionContext.get_context().initial_field_values = getattr(ExecutionContext.get_context(), 'global_field_values', {})
+        self.bound_field.activate_global_field_data_store(field_data_store)
         
         construction_state = self.view.get_construction_state()
         if construction_state:

--- a/reahl-web/reahl/web_dev/advanced/subresources/test_fieldvalidator.py
+++ b/reahl-web/reahl/web_dev/advanced/subresources/test_fieldvalidator.py
@@ -31,7 +31,7 @@ class ValidationScenarios(Fixture):
     @scenario
     def valid_field(self):
         # - a field that passes validation
-        self.url = Url('/__some_form_validate_method?field_name=valid@email.org')
+        self.url = Url('/__some_form_validate_method?some_form-field_name=valid@email.org')
         self.expected_body = 'true'
         self.expected_status = '200 OK' 
         self.expected_content_type = 'application/json'
@@ -40,7 +40,7 @@ class ValidationScenarios(Fixture):
     @scenario
     def failing_field(self):
         # - a field that fails one or more? constraints
-        self.url = Url('/__some_form_validate_method?field_name=invalidaddress')
+        self.url = Url('/__some_form_validate_method?some_form-field_name=invalidaddress')
         self.expected_body = '"field_name should be a valid email address"'
         self.expected_status = '200 OK' 
         self.expected_content_type = 'application/json'

--- a/reahl-web/reahl/web_dev/bootstrap/test_form.py
+++ b/reahl-web/reahl/web_dev/bootstrap/test_form.py
@@ -137,7 +137,7 @@ def test_adding_basic_input(web_fixture, form_layout_fixture):
 
     # form-group has an input, correctly set up for bootstrap
     assert input_widget.tag == 'input'
-    assert input_widget.attrib['name'] == 'an_attribute'
+    assert input_widget.attrib['name'] == 'aform-an_attribute'
 
 
 @with_fixtures(WebFixture, FormLayoutFixture)

--- a/reahl-web/reahl/web_dev/bootstrap/test_inputgroup.py
+++ b/reahl-web/reahl/web_dev/bootstrap/test_inputgroup.py
@@ -73,7 +73,7 @@ def test_input_group(web_fixture, input_group_fixture):
     children = outer_div.getchildren()
     the_input = children[1] if fixture.expects_before_html else children[0]
     assert the_input.tag == 'input'
-    assert the_input.name == 'an_attribute'
+    assert the_input.name == 'test-an_attribute'
 
     if fixture.expects_after_html:
         rendered_html = tester.get_html_for('//div/input/following-sibling::span')

--- a/reahl-web/reahl/web_dev/inputandvalidation/test_eventhandling.py
+++ b/reahl-web/reahl/web_dev/inputandvalidation/test_eventhandling.py
@@ -290,7 +290,7 @@ def test_distinguishing_identical_field_names(web_fixture):
             self.add_child(ButtonInput(self, self.events.an_event))
 
             self.add_child(TextInput(self, model_object1.fields.field_name))
-            self.add_child(TextInput(self, model_object2.fields.field_name.with_namespace('object2')))
+            self.add_child(TextInput(self, model_object2.fields.field_name.in_namespace('object2')))
 
     wsgi_app = fixture.new_wsgi_app(child_factory=MyForm.factory('form'))
     fixture.reahl_server.set_app(wsgi_app)

--- a/reahl-web/reahl/web_dev/inputandvalidation/test_eventhandling.py
+++ b/reahl-web/reahl/web_dev/inputandvalidation/test_eventhandling.py
@@ -290,7 +290,7 @@ def test_distinguishing_identical_field_names(web_fixture):
             self.add_child(ButtonInput(self, self.events.an_event))
 
             self.add_child(TextInput(self, model_object1.fields.field_name))
-            self.add_child(TextInput(self, model_object2.fields.field_name.in_namespace('object2')))
+            self.add_child(TextInput(self, model_object2.fields.field_name.with_discriminator('object2')))
 
     wsgi_app = fixture.new_wsgi_app(child_factory=MyForm.factory('form'))
     fixture.reahl_server.set_app(wsgi_app)
@@ -450,8 +450,8 @@ def test_form_preserves_user_input_after_validation_exceptions_multichoice(web_f
 
     browser.open('/')
 
-    no_validation_exception_input = '//select[@name="no_validation_exception_field[]"]'
-    validation_exception_input = '//select[@name="validation_exception_field[]"]'
+    no_validation_exception_input = '//select[@name="my_form-no_validation_exception_field[]"]'
+    validation_exception_input = '//select[@name="my_form-validation_exception_field[]"]'
 
     browser.select_many(no_validation_exception_input, ['One', 'Two'])
     browser.select_none(validation_exception_input) # select none to trigger the RequiredConstraint
@@ -488,7 +488,7 @@ def test_rendering_of_form(web_fixture):
 
     expected = '''<form id="test_channel" action="/a/b/_test_channel_method?x=y" data-formatter="/__test_channel_format_method" method="POST" class="reahl-form">''' \
                '''<div id="test_channel_hashes">'''\
-               '''<input name="test_channel-_reahl_database_concurrency_digest" id="id-test_channel-test_channel-_reahl_database_concurrency_digest" form="test_channel" type="hidden" value="" class="reahl-primitiveinput">''' \
+               '''<input name="test_channel-_reahl_database_concurrency_digest" id="id-test_channel-_reahl_database_concurrency_digest" form="test_channel" type="hidden" value="" class="reahl-primitiveinput">''' \
                '''</div>''' \
                '''</form>'''
     assert actual == expected
@@ -542,7 +542,7 @@ def test_check_missing_form(web_fixture):
     wsgi_app = fixture.new_wsgi_app(child_factory=MyPanel.factory())
     browser = Browser(wsgi_app)
 
-    expected_message = 'Could not find form for <TextInput name=name>. '\
+    expected_message = 'Could not find form for <TextInput name=myform-name>. '\
                        'Its form, <Form form id="myform".*> is not present on the current page'
 
     with expected(ProgrammerError, test=expected_message):
@@ -597,7 +597,7 @@ def test_nested_forms(web_fixture):
     browser = fixture.driver_browser
 
     browser.open('/')
-    browser.type(XPath.input_named('nested_field'), 'some nested input')
+    browser.type(XPath.input_named('my_nested_form-nested_field'), 'some nested input')
 
     browser.click(XPath.button_labelled('click nested'))
 
@@ -680,7 +680,7 @@ def test_form_input_validation(web_fixture):
     input_id = browser.get_id_of('//input[@type="text"]')
     assert label == '<label for="%s" class="error">field_name should be a valid email address</label>' % input_id
 
-    assert Session.query(UserInput).filter_by(key='field_name').count() == 1  # The invalid input was persisted
+    assert Session.query(UserInput).filter_by(key='myform-field_name').count() == 1  # The invalid input was persisted
     exception = Session.query(PersistedException).one().exception
     assert isinstance(exception, ValidationException)  # Is was persisted
     assert not exception.commit
@@ -693,7 +693,7 @@ def test_form_input_validation(web_fixture):
     browser.click("//input[@value='click me']")
     assert model_object.field_name == 'valid@home.org'
 
-    assert Session.query(UserInput).filter_by(key='field_name').count() == 0  # The invalid input was removed
+    assert Session.query(UserInput).filter_by(key='myform-field_name').count() == 0  # The invalid input was removed
     assert Session.query(PersistedException).count() == 0  # The exception was removed
 
     assert browser.current_url.path == '/page2'
@@ -833,7 +833,7 @@ def test_event_names_are_canonicalised(web_fixture):
     browser = Browser(wsgi_app)
 
     # when the Action is executed, the correct arguments are passed
-    browser.post('/__myform_method', {'event.an_event?some_argument=f~nnystuff': '', 'myform-_reahl_database_concurrency_digest':''})
+    browser.post('/__myform_method', {'event.myform-an_event?some_argument=f~nnystuff': '', 'myform-_reahl_database_concurrency_digest':''})
     assert model_object.received_argument == 'f~nnystuff'
 
 
@@ -874,7 +874,7 @@ def test_alternative_event_trigerring(web_fixture):
     browser = Browser(wsgi_app)
 
     # when POSTing with _noredirect, the Action is executed, but the browser is not redirected to /page2 as usual
-    browser.post('/__myform_method', {'event.an_event?': '', '_noredirect': '', 'myform-_reahl_database_concurrency_digest':''})
+    browser.post('/__myform_method', {'event.myform-an_event?': '', '_noredirect': '', 'myform-_reahl_database_concurrency_digest':''})
     browser.follow_response()  # Needed to make the test break should a HTTPTemporaryRedirect response be sent
     assert model_object.handled_event
     assert browser.current_url.path != '/page2'
@@ -911,10 +911,10 @@ def test_remote_field_validation(web_fixture):
     wsgi_app = fixture.new_wsgi_app(child_factory=MyForm.factory('myform'))
     browser = Browser(wsgi_app)
 
-    browser.open('/_myform_validate_method?a_field=invalid email address')
+    browser.open('/_myform_validate_method?myform-a_field=invalid email address')
     assert browser.raw_html == '"a_field should be a valid email address"'
 
-    browser.open('/_myform_validate_method?a_field=valid@email.org')
+    browser.open('/_myform_validate_method?myform-a_field=valid@email.org')
     assert browser.raw_html == 'true'
 
 
@@ -940,10 +940,10 @@ def test_remote_field_formatting(web_fixture):
     wsgi_app = fixture.new_wsgi_app(child_factory=MyForm.factory('myform'))
     browser = Browser(wsgi_app)
 
-    browser.open('/_myform_format_method?a_field=13 November 2012')
+    browser.open('/_myform_format_method?myform-a_field=13 November 2012')
     assert browser.raw_html == '13 Nov 2012'
 
-    browser.open('/_myform_format_method?a_field=invaliddate')
+    browser.open('/_myform_format_method?myform-a_field=invaliddate')
     assert browser.raw_html == ''
 
 

--- a/reahl-web/reahl/web_dev/inputandvalidation/test_field.py
+++ b/reahl-web/reahl/web_dev/inputandvalidation/test_field.py
@@ -81,7 +81,7 @@ def test_rendering_of_constraints(web_fixture, constraint_rendering_fixture):
     tester = WidgetTester(fixture.input)
 
     actual = tester.render_html()
-    expected_html = '''<input name="an_attribute" id="id-test-an_attribute" data-msg-one="validation_constraint 1 message" data-msg-two="validation_constraint 2 message with apostrophe&#x27;s and quotes&quot;" data-rule-one="true" data-rule-two="a parameter" form="test" type="inputtype" value="field value" class="reahl-primitiveinput">'''
+    expected_html = '''<input name="test-an_attribute" id="id-test-an_attribute" data-msg-one="validation_constraint 1 message" data-msg-two="validation_constraint 2 message with apostrophe&#x27;s and quotes&quot;" data-rule-one="true" data-rule-two="a parameter" form="test" type="inputtype" value="field value" class="reahl-primitiveinput">'''
     assert actual == expected_html
 
 

--- a/reahl-web/reahl/web_dev/inputandvalidation/test_input.py
+++ b/reahl-web/reahl/web_dev/inputandvalidation/test_input.py
@@ -170,46 +170,46 @@ class InputScenarios(SimpleInputFixture):
     @scenario
     def text_input(self):
         self.widget = TextInput(self.form, self.field)
-        self.expected_html = '<input name="an_attribute" id="id-test-an_attribute" form="test" type="text" value="field value" class="reahl-primitiveinput reahl-textinput">'
-        self.field_controls_visibility = True
+        self.expected_html = '<input name="test-an_attribute" id="id-test-an_attribute" form="test" type="text" value="field value" class="reahl-primitiveinput reahl-textinput">'
+        self.bound_field = self.widget.bound_field
 
     @scenario
     def text_input_placeholder_default(self):
         self.widget = TextInput(self.form, self.field, placeholder=True)
-        self.expected_html = '<input name="an_attribute" id="id-test-an_attribute" aria-label="the label" form="test" placeholder="the label" type="text" value="field value" class="reahl-primitiveinput reahl-textinput">'
-        self.field_controls_visibility = True
+        self.expected_html = '<input name="test-an_attribute" id="id-test-an_attribute" aria-label="the label" form="test" placeholder="the label" type="text" value="field value" class="reahl-primitiveinput reahl-textinput">'
+        self.bound_field = self.widget.bound_field
 
     @scenario
     def text_input_placeholder_specified(self):
         self.widget = TextInput(self.form, self.field, placeholder="some text")
-        self.expected_html = '<input name="an_attribute" id="id-test-an_attribute" aria-label="some text" form="test" placeholder="some text" type="text" value="field value" class="reahl-primitiveinput reahl-textinput">'
-        self.field_controls_visibility = True
+        self.expected_html = '<input name="test-an_attribute" id="id-test-an_attribute" aria-label="some text" form="test" placeholder="some text" type="text" value="field value" class="reahl-primitiveinput reahl-textinput">'
+        self.bound_field = self.widget.bound_field
 
     @scenario
     def input_label(self):
         html_input = TextInput(self.form, self.field)
         self.widget = Label(self.web_fixture.view, for_input=html_input)
         self.expected_html = '<label for="%s">the label</label>' % html_input.css_id
-        self.field_controls_visibility = True
+        self.bound_field = html_input.bound_field
 
     @scenario
     def input_label_with_text(self):
         html_input = TextInput(self.form, self.field)
         self.widget = Label(self.web_fixture.view, for_input=html_input, text='some text')
         self.expected_html = '<label for="%s">some text</label>' % html_input.css_id
-        self.field_controls_visibility = True
+        self.bound_field = html_input.bound_field
 
     @scenario
     def button_input(self):
         self.widget = self.form.add_child(ButtonInput(self.form, self.event))
-        self.expected_html = '<input name="event.aname?" id="id-test-event-46-aname-63-" form="test" type="submit" value="click me" class="reahl-primitiveinput">'
-        self.field_controls_visibility = False
+        self.expected_html = '<input name="event.test-aname?" id="id-event-46-test-aname-63-" form="test" type="submit" value="click me" class="reahl-primitiveinput">'
+        self.bound_field = self.widget.bound_field
 
     @scenario
     def password(self):
         self.widget = self.form.add_child(PasswordInput(self.form, self.field))
-        self.expected_html = '<input name="an_attribute" id="id-test-an_attribute" form="test" type="password" class="reahl-primitiveinput">'
-        self.field_controls_visibility = True
+        self.expected_html = '<input name="test-an_attribute" id="id-test-an_attribute" form="test" type="password" class="reahl-primitiveinput">'
+        self.bound_field = self.widget.bound_field
 
     def setup_checkbox_scenario(self, boolean_value):
         self.model_object.an_attribute = boolean_value
@@ -218,25 +218,25 @@ class InputScenarios(SimpleInputFixture):
         self.field.bind('an_attribute', self.model_object)
 
         self.widget = self.form.add_child(CheckboxInput(self.form, self.field))
-        self.field_controls_visibility = True
+        self.bound_field = self.widget.bound_field
 
     @scenario
     def checkbox_true(self):
         """A checkbox needs a 'checked' an_attribute if its field is True. It also renders ONLY the
             validation message for its required validation_constraint, not for all constraints"""
         self.setup_checkbox_scenario(True)
-        self.expected_html = '<input name="an_attribute" id="id-test-an_attribute" checked="checked" data-false-boolean-value="off" data-is-boolean="" data-msg-required="my text is needed here" data-true-boolean-value="on" form="test" required="*" type="checkbox" class="reahl-primitiveinput">'
+        self.expected_html = '<input name="test-an_attribute" id="id-test-an_attribute" checked="checked" data-false-boolean-value="off" data-is-boolean="" data-msg-required="my text is needed here" data-true-boolean-value="on" form="test" required="*" type="checkbox" class="reahl-primitiveinput">'
 
     @scenario
     def checkbox_false(self):
         self.setup_checkbox_scenario(False)
-        self.expected_html = '<input name="an_attribute" id="id-test-an_attribute" data-false-boolean-value="off" data-is-boolean="" data-msg-required="my text is needed here" data-true-boolean-value="on" form="test" required="*" type="checkbox" class="reahl-primitiveinput">'
+        self.expected_html = '<input name="test-an_attribute" id="id-test-an_attribute" data-false-boolean-value="off" data-is-boolean="" data-msg-required="my text is needed here" data-true-boolean-value="on" form="test" required="*" type="checkbox" class="reahl-primitiveinput">'
 
     @scenario
     def text_area_input(self):
         self.widget = self.form.add_child(TextArea(self.form, self.field, rows=30, columns=20))
-        self.expected_html = '<textarea name="an_attribute" id="id-test-an_attribute" cols="20" rows="30" class="reahl-primitiveinput">field value</textarea>'
-        self.field_controls_visibility = True
+        self.expected_html = '<textarea name="test-an_attribute" id="id-test-an_attribute" cols="20" rows="30" class="reahl-primitiveinput">field value</textarea>'
+        self.bound_field = self.widget.bound_field
 
     @scenario
     def select_input(self):
@@ -256,8 +256,8 @@ class InputScenarios(SimpleInputFixture):
                                   '<option id="id-test-an_attribute-2" selected="selected" value="2">Two</option>'+\
                 '</optgroup>'
         option = '<option id="id-test-an_attribute-off" value="off">None</option>'
-        self.expected_html = r'<select name="an_attribute" id="id-test-an_attribute" form="test" class="reahl-primitiveinput">%s%s</select>' % (option, group)
-        self.field_controls_visibility = True
+        self.expected_html = r'<select name="test-an_attribute" id="id-test-an_attribute" form="test" class="reahl-primitiveinput">%s%s</select>' % (option, group)
+        self.bound_field = self.widget.bound_field
 
     @scenario
     def select_input_multi(self):
@@ -270,8 +270,8 @@ class InputScenarios(SimpleInputFixture):
 
         self.widget = self.form.add_child(SelectInput(self.form, self.field))
         options = '<option id="id-test-an_attribute-91--93--1" value="1">One</option><option id="id-test-an_attribute-91--93--2" selected="selected" value="2">Two</option>'
-        self.expected_html = '<select name="an_attribute[]" id="id-test-an_attribute-91--93-" form="test" multiple="multiple" class="reahl-primitiveinput">%s</select>' % (options)
-        self.field_controls_visibility = True
+        self.expected_html = '<select name="test-an_attribute[]" id="id-test-an_attribute-91--93-" form="test" multiple="multiple" class="reahl-primitiveinput">%s</select>' % (options)
+        self.bound_field = self.widget.bound_field
 
     @scenario
     def checkbox_input_multi(self):
@@ -286,12 +286,12 @@ class InputScenarios(SimpleInputFixture):
         self.field.bind('an_attribute', self.model_object)
 
         self.widget = self.form.add_child(CheckboxSelectInput(self.form, self.field))
-        not_checked_option = r'<label><input name="an_attribute[]" id="id-test-an_attribute-91--93--1" form="test" type="checkbox" value="1">One</label>'
-        checked_options = r'<label><input name="an_attribute[]" id="id-test-an_attribute-91--93--2" checked="checked" form="test" type="checkbox" value="2">Two</label>'
-        checked_options += r'<label><input name="an_attribute[]" id="id-test-an_attribute-91--93--3" checked="checked" form="test" type="checkbox" value="3">Three</label>'
+        not_checked_option = r'<label><input name="test-an_attribute[]" id="id-test-an_attribute-91--93--1" form="test" type="checkbox" value="1">One</label>'
+        checked_options = r'<label><input name="test-an_attribute[]" id="id-test-an_attribute-91--93--2" checked="checked" form="test" type="checkbox" value="2">Two</label>'
+        checked_options += r'<label><input name="test-an_attribute[]" id="id-test-an_attribute-91--93--3" checked="checked" form="test" type="checkbox" value="3">Three</label>'
         options = not_checked_option + checked_options
         self.expected_html = r'<div class="reahl-checkbox-input reahl-primitiveinput">%s</div>' % (options)
-        self.field_controls_visibility = True
+        self.bound_field = self.widget.bound_field
 
     @scenario
     def radio_button(self):
@@ -305,7 +305,7 @@ class InputScenarios(SimpleInputFixture):
         self.widget = self.form.add_child(RadioButtonSelectInput(self.form, self.field))
 
         radio_button = '<label>'\
-                       '<input name="an_attribute" id="id-test-an_attribute-%s"%s '\
+                       '<input name="test-an_attribute" id="id-test-an_attribute-%s"%s '\
                               'data-msg-pattern="an_attribute should be one of the following: 1|2" '\
                               '%s'\
                               'form="test" pattern="(1|2)" '\
@@ -317,7 +317,7 @@ class InputScenarios(SimpleInputFixture):
         buttons = (radio_button % ('1', '', '', '1', 'One')) +\
                   (radio_button % ('2', ' checked="checked"', '', '2', 'Two'))
         self.expected_html = outer_div % buttons
-        self.field_controls_visibility = True
+        self.bound_field = self.widget.bound_field
 
 
 @with_fixtures(InputScenarios)
@@ -338,13 +338,12 @@ def test_rendering_when_not_allowed(input_scenarios):
 
     tester = WidgetTester(fixture.widget)
 
-    fixture.field.access_rights.readable = Allowed(False)
-    fixture.field.access_rights.writable = Allowed(False)
+    fixture.bound_field.access_rights.readable = Allowed(False)
+    fixture.bound_field.access_rights.writable = Allowed(False)
+
     actual = tester.render_html()
-    if fixture.field_controls_visibility:
-        assert actual == ''
-    else:
-        assert actual == fixture.expected_html
+    assert actual == ''
+
 
 
 @with_fixtures(FieldFixture, SimpleInputFixture)
@@ -381,10 +380,10 @@ def test_wrong_args_to_input(simple_input_fixture):
     fixture = simple_input_fixture
 
     with expected(IsInstance):
-        PrimitiveInput(fixture.form, EmptyStub())
+        PrimitiveInput(fixture.form, EmptyStub(in_namespace=lambda self: self))
 
     with expected(IsInstance):
-        PrimitiveInput(EmptyStub(), Field())
+        PrimitiveInput(EmptyStub(channel_name='test'), Field())
 
 
 @with_fixtures(WebFixture, SimpleInputFixture2)
@@ -589,8 +588,8 @@ def test_fuzzy(web_fixture, fuzzy_text_input_fixture):
     browser = web_fixture.driver_browser
     browser.open('/')
 
-    browser.type(XPath.input_named('an_attribute'), '20 November 2012')
+    browser.type(XPath.input_named('myform-an_attribute'), '20 November 2012')
     browser.press_tab()
-    browser.wait_for(browser.is_element_value, XPath.input_named('an_attribute'), '20 Nov 2012')
+    browser.wait_for(browser.is_element_value, XPath.input_named('myform-an_attribute'), '20 Nov 2012')
 
 

--- a/reahl-web/reahl/web_dev/inputandvalidation/test_optimistic_locking.py
+++ b/reahl-web/reahl/web_dev/inputandvalidation/test_optimistic_locking.py
@@ -250,20 +250,20 @@ def test_optimistic_concurrency_participation(scenario):
 
 @uses(input_fixture=SimpleInputFixture)
 class ChangeScenarios(Fixture):
-    readable = True
+    writable = True
     def new_input_widget(self):
-        return PrimitiveInputStub(self.input_fixture.form, self.input_fixture.new_field(readable=lambda field: self.readable))
+        return PrimitiveInputStub(self.input_fixture.form, self.input_fixture.new_field(writable=lambda field: self.writable))
 
-    def set_unreadable(self):
-        self.readable = False
+    def set_unwritable(self):
+        self.writable = False
 
     def change_domain_value(self):
         self.input_widget.bound_field.bound_to.an_attribute = 'changed'
         
     @scenario
     def change_readability(self):
-        """When the readability of an input changes, that counts as a change"""
-        self.change_something = self.set_unreadable
+        """When the input changes between being disabled and enabled, that counts as a change"""
+        self.change_something = self.set_unwritable
 
     @scenario
     def change_value(self):
@@ -278,6 +278,7 @@ def test_optimistic_concurrency_what_constitutes_a_change(web_fixture, input_fix
 
     before_hash = input_widget.get_concurrency_hash_digest()
     scenario.change_something()
+    input_widget.bound_field.activate_initial_value_store({}) # To simulate the Input being constructed twice and the comparison happening after the second
     assert before_hash != input_widget.get_concurrency_hash_digest()
 
 

--- a/reahl-web/reahl/web_dev/inputandvalidation/test_optimistic_locking.py
+++ b/reahl-web/reahl/web_dev/inputandvalidation/test_optimistic_locking.py
@@ -278,7 +278,7 @@ def test_optimistic_concurrency_what_constitutes_a_change(web_fixture, input_fix
 
     before_hash = input_widget.get_concurrency_hash_digest()
     scenario.change_something()
-    input_widget.bound_field.activate_initial_value_store({}) # To simulate the Input being constructed twice and the comparison happening after the second
+    input_widget.bound_field.activate_global_field_data_store({}) # To simulate the Input being constructed twice and the comparison happening after the second
     assert before_hash != input_widget.get_concurrency_hash_digest()
 
 

--- a/reahl-web/reahl/web_dev/inputandvalidation/test_responsive_disclosure.py
+++ b/reahl-web/reahl/web_dev/inputandvalidation/test_responsive_disclosure.py
@@ -256,7 +256,7 @@ def test_overridden_names(web_fixture, query_string_fixture, responsive_disclosu
     fixture.ModelObject = ModelObject
 
     def create_trigger_input(form, an_object):
-        the_input = CheckboxSelectInput(form, an_object.fields.choice.in_namespace('first'), refresh_widget=form)
+        the_input = CheckboxSelectInput(form, an_object.fields.choice.with_discriminator('first'), refresh_widget=form)
         the_input.set_id('marvin')
         return the_input
     fixture.create_trigger_input = create_trigger_input
@@ -274,7 +274,7 @@ def test_overridden_names(web_fixture, query_string_fixture, responsive_disclosu
     browser = web_fixture.driver_browser
     browser.open('/')
 
-    browser.click('//input[@name="first-choice[]" and @value="3"]')
+    browser.click('//input[@name="myform-first-choice[]" and @value="3"]')
     assert browser.wait_for(query_string_fixture.is_state_now, [1,3])
 
 
@@ -1098,7 +1098,7 @@ def test_invalid_trigger_inputs(web_fixture, query_string_fixture, sql_alchemy_f
         assert browser.wait_for(query_string_fixture.is_state_labelled_now, 'My calculated state', '5')
 
         # Case: Entering an invalid value does not trigger a refresh of the input doing the triggering
-        with web_fixture.driver_browser.no_load_expected_for('input[name="choice"]'):
+        with web_fixture.driver_browser.no_load_expected_for('input[name="myform-choice"]'):
             browser.type(XPath.input_labelled('Choice'), 'invalid value')
 
         # Case: Entering an valid value in a different trigger, triggers a refresh, but last valid value of choice is used
@@ -1192,3 +1192,8 @@ def test_invalid_non_trigger_input_corner_case(web_fixture, query_string_fixture
         assert browser.is_element_present(XPath.paragraph().including_text('An exception happened on submit'))
         assert browser.is_element_value(XPath.input_labelled('Choice3'), '8')
 
+
+# TODO: What about when you have multiple Forms on a page, with an input on both Forms that uses a Field bound to the same name on the same domain object?
+#       Upon Ajax, all form inputs are submitted, not just one. It may be that their processing is ordered such that the one that never refreshes always happens last.
+#       Because it happens last, it always overwrites the value to the old non-refreshed value and nothing ever changes?
+#       One idea: first accept_input for all inputs outside of the widget being refreshed. Then the inputs in that Widget. Then the actual input which triggered the change. ?

--- a/reahl-web/reahl/web_dev/inputandvalidation/test_responsive_disclosure.py
+++ b/reahl-web/reahl/web_dev/inputandvalidation/test_responsive_disclosure.py
@@ -256,7 +256,7 @@ def test_overridden_names(web_fixture, query_string_fixture, responsive_disclosu
     fixture.ModelObject = ModelObject
 
     def create_trigger_input(form, an_object):
-        the_input = CheckboxSelectInput(form, an_object.fields.choice.with_namespace('first'), refresh_widget=form)
+        the_input = CheckboxSelectInput(form, an_object.fields.choice.in_namespace('first'), refresh_widget=form)
         the_input.set_id('marvin')
         return the_input
     fixture.create_trigger_input = create_trigger_input

--- a/reahl-web/reahl/web_dev/inputandvalidation/test_widgetqueryargs.py
+++ b/reahl-web/reahl/web_dev/inputandvalidation/test_widgetqueryargs.py
@@ -120,7 +120,7 @@ def test_query_string_prepopulates_form(web_fixture, value_scenarios):
     wsgi_app = web_fixture.new_wsgi_app(enable_js=True, child_factory=FormWithQueryArguments.factory())
     browser = Browser(wsgi_app)
 
-    browser.open('/?%s' % fixture.field_on_query_string.format(field_name='arg_on_other_object'))
+    browser.open('/?%s' % fixture.field_on_query_string.format(field_name='name-arg_on_other_object'))
     assert browser.get_value(XPath.input_labelled('field')) == fixture.field_value_as_string
 
 

--- a/reahl-web/reahl/web_dev/test_security.py
+++ b/reahl-web/reahl/web_dev/test_security.py
@@ -142,7 +142,7 @@ class InputRenderingScenarios(Fixture):
         self.writable = Allowed(True)
         self.input_widget = TextInput(self.form, self.field)
 
-        self.expected_html = '<input name="field_name" id="id-some_form-field_name" form="some_form" type="text" value="3" class="reahl-primitiveinput reahl-textinput">'
+        self.expected_html = '<input name="some_form-field_name" id="id-some_form-field_name" form="some_form" type="text" value="3" class="reahl-primitiveinput reahl-textinput">'
 
     @scenario
     def disabled_rendering(self):
@@ -150,7 +150,7 @@ class InputRenderingScenarios(Fixture):
         self.writable = Allowed(False)
         self.input_widget = TextInput(self.form, self.field)
 
-        self.expected_html = '<input name="field_name" id="id-some_form-field_name" disabled="disabled" form="some_form" type="text" value="3" class="reahl-primitiveinput reahl-textinput">'
+        self.expected_html = '<input name="some_form-field_name" id="id-some_form-field_name" disabled="disabled" form="some_form" type="text" value="3" class="reahl-primitiveinput reahl-textinput">'
 
     @scenario
     def valueless_rendering(self):
@@ -158,7 +158,7 @@ class InputRenderingScenarios(Fixture):
         self.writable = Allowed(True)
         self.input_widget = TextInput(self.form, self.field)
 
-        self.expected_html = '<input name="field_name" id="id-some_form-field_name" form="some_form" type="text" value="" class="reahl-primitiveinput reahl-textinput">'
+        self.expected_html = '<input name="some_form-field_name" id="id-some_form-field_name" form="some_form" type="text" value="" class="reahl-primitiveinput reahl-textinput">'
 
     @scenario
     def empty_rendering(self):
@@ -174,7 +174,7 @@ class InputRenderingScenarios(Fixture):
         self.writable = Allowed(True)
         self.input_widget = ButtonInput(self.form, self.event)
 
-        self.expected_html = '<input name="event.event_name?" id="id-some_form-event-46-event_name-63-" form="some_form" type="submit" value="event_name" class="reahl-primitiveinput">'
+        self.expected_html = '<input name="event.some_form-event_name?" id="id-event-46-some_form-event_name-63-" form="some_form" type="submit" value="event_name" class="reahl-primitiveinput">'
 
     @scenario
     def greyed_button_rendering(self):
@@ -182,7 +182,7 @@ class InputRenderingScenarios(Fixture):
         self.writable = Allowed(False)
         self.input_widget = ButtonInput(self.form, self.event)
 
-        self.expected_html = '<input name="event.event_name?" id="id-some_form-event-46-event_name-63-" disabled="disabled" form="some_form" type="submit" value="event_name" class="reahl-primitiveinput">'
+        self.expected_html = '<input name="event.some_form-event_name?" id="id-event-46-some_form-event_name-63-" disabled="disabled" form="some_form" type="submit" value="event_name" class="reahl-primitiveinput">'
 
     @scenario
     def buttons_must_be_readable_to_be_present(self):
@@ -271,6 +271,7 @@ def test_non_writable_input_is_dealt_with_like_invalid_input(web_fixture):
             form.define_event_handler(model_object.events.an_event)
             form.add_child(ButtonInput(form, model_object.events.an_event))
             form.add_child(TextInput(form, model_object.fields.field_name))
+
             fixture.form = form
 
 
@@ -278,7 +279,7 @@ def test_non_writable_input_is_dealt_with_like_invalid_input(web_fixture):
     browser = Browser(wsgi_app)
     browser.open('/')
 
-    browser.post(fixture.form.event_channel.get_url().path, {'event.an_event?':'', 'field_name': 'illigitimate value', 'some_form-_reahl_database_concurrency_digest':''})
+    browser.post(fixture.form.event_channel.get_url().path, {'event.some_form-an_event?':'', 'some_form-field_name': 'illigitimate value', 'some_form-_reahl_database_concurrency_digest':''})
     browser.follow_response()
     assert model_object.field_name == 'Original value'
 
@@ -310,10 +311,10 @@ def test_non_writable_events_are_dealt_with_like_invalid_input(web_fixture):
     browser = Browser(wsgi_app)
     browser.open('/')
 
-    browser.post(fixture.form.event_channel.get_url().path, {'event.an_event?':'', 'some_form-_reahl_database_concurrency_digest':''})
+    browser.post(fixture.form.event_channel.get_url().path, {'event.some_form-an_event?':'', 'some_form-_reahl_database_concurrency_digest':''})
     browser.follow_response()
     error_label = browser.get_html_for('//label')
-    input_id = browser.get_id_of('//input[@name="event.an_event?"]')
+    input_id = browser.get_id_of('//input[@name="event.some_form-an_event?"]')
     assert error_label == '<label for="%s" class="error">you cannot do this</label>' % input_id
 
 


### PR DESCRIPTION
Ensure that the concurrency hash always has the initial database value for fields no matter what.
Put the fields for each form inside a namespace for that form thus ensuring uniquely named fields per page.
Added with_discriminator (related to the private in_namespace) for users to be able to discriminate safely between fields on the same form.