### PR TITLE
Wrong path separator causes issues on Windows

### DIFF
--- a/reahl-component/reahl/component/eggs.py
+++ b/reahl-component/reahl/component/eggs.py
@@ -398,7 +398,7 @@ class ReahlEgg:
         dir_or_egg_name = translations_entry_point.dist.location.split(os.sep)[-1]
         paths = [p for p in module.__path__ if p.find('%s%s' % (dir_or_egg_name, os.path.sep)) > 0]
         paths = [p for p in paths if not p.startswith(os.path.join(translations_entry_point.dist.location, '.'))]
-        unique_paths = [p.split('%s/' % dir_or_egg_name)[-1] for p in paths]
+        unique_paths = [p.split('%s%s' % (dir_or_egg_name, os.path.sep))[-1] for p in paths]
         unique_paths = set([p for p in unique_paths if '.egg' not in p])
         assert len(unique_paths) <= 1, \
             'Only one translations package per component is allowed, found %s for %s' % (paths, translations_entry_point.dist)


### PR DESCRIPTION
Fixed another issue related to #271 