### PR TITLE
Gpg sign errors on Travis

### DIFF
--- a/travis/createTestGpgKey.sh
+++ b/travis/createTestGpgKey.sh
@@ -59,6 +59,7 @@ if [ "$TRAVIS_SECURE_ENV_VARS" == 'true' ]; then
 else
   echo "SECRETS NOT available, using fake key for signing"
 fi
+echo "no-tty" >> ~/.gnupg/gpg.conf
 
 import_gpg_keys travis/keys  # We import these anyways for use by tests that sign stuff
 


### PR DESCRIPTION
E: read, still have 8 to read but none left
E: Errors apply to file './equivs-dummy_1.0_all.deb'
gpg: using "31E6D14EE2BBF650" as default secret key for signing
gpg: signing failed: Inappropriate ioctl for device
gpg: signing failed: Inappropriate ioctl for device

ioctl seems to relate to "no tty"